### PR TITLE
chore(deps): upgrade packages and migrate build to PEP 517 isolation

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -4,7 +4,7 @@ This guide explains how to set up a local development environment for `acc-fwu`.
 
 ## Prerequisites
 
-- Python 3.6 or higher
+- Python 3.9 or higher
 - pip (Python package installer)
 - git
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A tool to automatically update the [Akamai Connected Cloud (ACC) / Linode](https
 
 ## Prerequisites
 
-- Python 3.6 or higher
+- Python 3.9 or higher
 - [Linode CLI](https://www.linode.com/docs/products/tools/cli/get-started/) configured with an API token
 - A Linode/ACC firewall ID
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=64.0.0", "wheel"]
+requires = ["setuptools>=82.0.1", "setuptools_scm>=8", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=82.0.1", "setuptools_scm>=8", "wheel"]
+requires = ["setuptools>=82.0.1", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-certifi==2026.1.4
-charset-normalizer==3.4.4
+certifi==2026.2.25
+charset-normalizer==3.4.7
 idna==3.11
-requests==2.32.5
+requests==2.33.1
 urllib3==2.6.3

--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,5 @@ setup(
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.9",
 )

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ with open("README.md") as f:
 setup(
     name="acc-fwu",
     use_scm_version=True,  # Use setuptools_scm for versioning
-    setup_requires=["setuptools_scm"],  # Ensure setuptools_scm is available during setup
     package_dir={"": "src"},  # Sets 'src' as the root directory for packages
     packages=find_packages(where="src"),  # Finds packages in the 'src' directory
     install_requires=[


### PR DESCRIPTION
## Summary
- Upgrades runtime deps and the setuptools build requirement, consolidating three pending dependabot PRs (#46, #50, #51) and resolving Mend alert #49.
- Migrates `setuptools_scm` from the deprecated `setup_requires` egg-fetch path to `pyproject.toml` `build-system.requires`, fixing `ModuleNotFoundError: No module named 'vcs_versioning'` that blocked the CI Build step on Python 3.14 + setuptools ≥82 (which removes `pkg_resources`).
- Patches CVE-2026-25645 (insecure temp file reuse in `requests.utils.extract_zipped_paths`) by bumping `requests` to `2.33.1`.

### Package bumps
| package | from | to |
| --- | --- | --- |
| `requests` | 2.32.5 | 2.33.1 |
| `certifi` | 2026.1.4 | 2026.2.25 |
| `charset-normalizer` | 3.4.4 | 3.4.7 |
| setuptools build req | >=64.0.0 | >=82.0.1 |

## Test plan
- [x] `pytest` — 105/105 pass locally
- [x] `flake8 . --select=E9,F63,F7,F82` — clean
- [x] `python -m build` — wheel + sdist produced with isolated build env
- [ ] CI: Test, Scan, Build pass on Python 3.x (3.14) with new setuptools/setuptools_scm
- [ ] After merge: tag `v0.2.3`, create GitHub Release, PyPI publish runs from the release event

Closes #49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)