### PR TITLE
feat: LKE auto-updates by default, show active firewall, dynamic list tables

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,8 @@ This file provides guidance for AI assistants working with the `acc-fwu` (Akamai
 - Input validation for security
 - Interactive firewall selection (lists available firewalls)
 - Add mode for multiple IP addresses (travel use case)
-- LKE / LKE-E Control Plane ACL automation (`--lke`)
+- LKE / LKE-E Control Plane ACL automation runs by default alongside firewall updates (`--no-lke` to skip, `--lke` for LKE-only mode)
+- Prints the active firewall ID/label when loaded from config so the user sees which firewall is being touched
 
 ## Codebase Structure
 
@@ -68,13 +69,17 @@ python -m build
 ## Key Code Patterns
 
 ### Architecture
-- **`cli.py`**: Handles argument parsing and orchestrates calls to `firewall.py`. Refactored into small helper functions:
+- **`cli.py`**: Handles argument parsing and orchestrates calls to `firewall.py` / `lke.py`. Refactored into small helper functions:
   - `_create_parser()` - Builds the argparse parser
-  - `_handle_list_command(debug)` - Handles `--list` flag
+  - `_print_table(title, headers, rows)` - Renders a table with columns auto-sized to the widest cell (used by both firewall and LKE list commands)
+  - `_handle_list_command(debug)` - Handles `--list` flag for firewalls
+  - `_handle_lke_list_command()` / `_handle_lke_command(args)` - LKE-specific list and update dispatch
   - `_resolve_firewall_config(args)` - Resolves config from args, file, or interactive selection
-  - `_resolve_config_from_args(args)` / `_resolve_config_from_file(label)` / `_resolve_config_interactive(args)` - Config resolution helpers
+  - `_resolve_config_from_args(args)` / `_resolve_config_from_file(label, quiet)` / `_resolve_config_interactive(args)` - Config resolution helpers. `_resolve_config_from_file` prints the active firewall ID/label unless `quiet`.
   - `_execute_firewall_operation(args, firewall_id, label)` - Dispatches update or remove
+  - `main()` - After the firewall operation, calls `update_all_lke_acls(..., implicit=True)` unless `--no-lke` is set
 - **`firewall.py`**: Contains all business logic, API interactions, and validation
+- **`lke.py`**: LKE/LKE-E cluster enumeration and Control Plane ACL mutation
 
 ### Validation Functions (firewall.py)
 All inputs are validated before use:
@@ -254,10 +259,13 @@ The tool uses the Linode API v4:
   cluster uniformly.
 - `put_lke_acl(cluster_id, acl, headers=None, debug=False)` - Wraps the ACL in
   the `{"acl": {...}}` envelope the PUT endpoint expects.
-- `update_all_lke_acls(debug, quiet, dry_run, remove)` - Orchestrator. Iterates
-  clusters and applies `_apply_ip_to_acl` to add/remove the current public IP.
-  Per-cluster fetch/PUT failures are logged and counted (`failed`) but do not
-  abort the batch. Returns `{"changed", "unchanged", "failed", "total"}`.
+- `update_all_lke_acls(debug, quiet, dry_run, remove, implicit=False)` -
+  Orchestrator. Iterates clusters and applies `_apply_ip_to_acl` to add/remove
+  the current public IP. Per-cluster fetch/PUT failures are logged and counted
+  (`failed`) but do not abort the batch. When `implicit=True` (the default
+  firewall+LKE path driven by `main()`), the "No LKE clusters found" notice is
+  suppressed so users without any clusters see no extra output. Returns
+  `{"changed", "unchanged", "failed", "total"}`.
 
 ## File Locations
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ A tool to automatically update the [Akamai Connected Cloud (ACC) / Linode](https
 - Secure configuration file storage (owner-only permissions)
 - **Interactive firewall selection** - List and choose from available firewalls
 - **Add mode** - Accumulate multiple IP addresses (ideal for traveling)
-- **LKE Control Plane ACL automation** - Apply your current IP to every LKE and LKE-E cluster's Control Plane ACL with a single command
+- **LKE Control Plane ACL automation** - Every run also syncs your public IP into every LKE and LKE-E cluster's Control Plane ACL (opt-out with `--no-lke`; use `--lke` for LKE-only mode)
+- **Active firewall indicator** - When the config file is used, `acc-fwu` prints the firewall ID and label it's operating on
 
 ## Prerequisites
 
@@ -79,12 +80,14 @@ acc-fwu
 This will:
 
 1. Load the saved `firewall_id` and `label` from the configuration file.
-2. Update the firewall rule with your current public IP address.
+2. Print the active firewall (for example `Using saved firewall: ID 123456, label 'My-IP' (from ~/.acc-fwu-config)`).
+3. Update the firewall rule with your current public IP address.
+4. Sync your current public IP into every LKE / LKE-E Control Plane ACL in your account. Pass `--no-lke` to skip this step.
 
 ### Command-Line Options
 
 ```
-usage: acc-fwu [-h] [--firewall_id FIREWALL_ID] [--label LABEL] [-d] [-r] [-a] [-l] [--lke] [-q] [--dry-run] [-v]
+usage: acc-fwu [-h] [--firewall_id FIREWALL_ID] [--label LABEL] [-d] [-r] [-a] [-l] [--lke] [--no-lke] [-q] [--dry-run] [-v]
 
 Create, update, or remove Akamai Connected Cloud (Linode) firewall rules with your current IP address.
 
@@ -97,8 +100,10 @@ options:
   -r, --remove          Remove the specified rules from the firewall.
   -a, --add             Add IP to existing rules instead of replacing (useful for multiple locations).
   -l, --list            List available firewalls (or LKE clusters with --lke) and exit.
-  --lke                 Target LKE/LKE-E Control Plane ACLs instead of firewall rules.
+  --lke                 Target LKE/LKE-E Control Plane ACLs only; skip firewall rules.
                         Adds (or removes with -r) your current public IP to every cluster's ACL.
+  --no-lke              Skip the default LKE/LKE-E Control Plane ACL update.
+                        By default, acc-fwu updates both firewall rules and LKE ACLs.
   -q, --quiet           Suppress output messages (useful for cron/scripting).
   --dry-run             Show what would be done without making any changes.
   -v, --version         show program's version number and exit
@@ -184,7 +189,9 @@ acc-fwu  # Creates new rules with only your current IP
 
 ### LKE / LKE-E Control Plane ACLs
 
-The `--lke` flag automates [Control Plane ACL](https://techdocs.akamai.com/linode-api/reference/put-lke-cluster-acl) updates for every LKE and LKE-Enterprise (LKE-E) cluster in your account. It fetches each cluster's current ACL, then appends (or removes) your public IP — preserving the `enabled` state and any existing IPv4/IPv6 entries.
+`acc-fwu` automates [Control Plane ACL](https://techdocs.akamai.com/linode-api/reference/put-lke-cluster-acl) updates for every LKE and LKE-Enterprise (LKE-E) cluster in your account. For each cluster it fetches the current ACL, then appends (or removes) your public IP — preserving the `enabled` state and any existing IPv4/IPv6 entries.
+
+**Default behaviour (since v0.3.1):** every firewall update also syncs your IP into each cluster's Control Plane ACL. Accounts with no clusters see no extra output. Pass `--no-lke` to skip it, or `--lke` for LKE-only mode.
 
 **List all LKE / LKE-E clusters:**
 
@@ -192,7 +199,13 @@ The `--lke` flag automates [Control Plane ACL](https://techdocs.akamai.com/linod
 acc-fwu --lke --list
 ```
 
-**Add your current IP to every cluster's Control Plane ACL (idempotent):**
+**Skip the LKE step while still updating firewall rules:**
+
+```bash
+acc-fwu --no-lke
+```
+
+**LKE-only mode (skip firewall rule updates entirely):**
 
 ```bash
 acc-fwu --lke
@@ -213,7 +226,10 @@ acc-fwu --lke --remove
 **Run silently in a cron job:**
 
 ```bash
-# Refresh LKE ACLs every 15 minutes
+# Refresh firewall rules + LKE ACLs every 15 minutes
+*/15 * * * * /usr/local/bin/acc-fwu --quiet
+
+# Or, LKE only
 */15 * * * * /usr/local/bin/acc-fwu --lke --quiet
 ```
 
@@ -263,6 +279,17 @@ The project uses multiple GitHub Actions workflows for quality assurance:
 This project is licensed under the GNU General Public License v3 (GPLv3) - see the [LICENSE](LICENSE) file for details.
 
 ## Summary of Changes
+
+### 2026-04-18 - v0.3.1
+
+- **New Features**:
+  - LKE/LKE-E Control Plane ACL updates now run by default alongside firewall rule updates — no separate invocation needed. Pass `--no-lke` to opt out, or keep `--lke` for LKE-only runs.
+  - `acc-fwu` now prints the saved firewall (ID + label) it's operating on whenever configuration is loaded from `~/.acc-fwu-config`, so you can see exactly which firewall is being touched.
+  - `--list` tables (both firewalls and LKE clusters) now auto-size each column to its widest value, so long names like `resilio-sync-jumpbox-fw-e4e83e29` no longer break alignment.
+- **Dependency & Build Updates**:
+  - Upgraded `requests` 2.32.5 → 2.33.1 (addresses CVE-2026-25645, insecure temp file reuse in `extract_zipped_paths`).
+  - Upgraded `certifi` to 2026.2.25 and `charset-normalizer` to 3.4.7.
+  - Moved `setuptools_scm` to `pyproject.toml` `build-system.requires` so PEP 517 build isolation handles it, fixing the `vcs_versioning` import failure seen on Python 3.14 + setuptools 82.
 
 ### 2026-04-17 - v0.3.0
 

--- a/src/acc_fwu/cli.py
+++ b/src/acc_fwu/cli.py
@@ -1,6 +1,7 @@
 import argparse
 import sys
 from .firewall import (
+    CONFIG_FILE_PATH,
     update_firewall_rule,
     remove_firewall_rule,
     load_config,
@@ -23,6 +24,23 @@ except ImportError:
     __version__ = "0.0.0-dev"
 
 
+def _print_table(title, headers, rows):
+    """Print a table with columns auto-sized to their widest row."""
+    widths = [
+        max(len(h), *(len(str(row[i])) for row in rows))
+        for i, h in enumerate(headers)
+    ]
+    total = sum(widths) + 2 * (len(headers) - 1)
+
+    print(f"\n{title}")
+    print("-" * total)
+    print("  ".join(f"{h:<{w}}" for h, w in zip(headers, widths)))
+    print("-" * total)
+    for row in rows:
+        print("  ".join(f"{str(v):<{w}}" for v, w in zip(row, widths)))
+    print("-" * total)
+
+
 def _handle_list_command(debug):
     """Handle the --list command to display available firewalls."""
     firewalls = list_firewalls()
@@ -30,13 +48,8 @@ def _handle_list_command(debug):
         print("No firewalls found in your Linode account.")
         return
 
-    print("\nAvailable firewalls:")
-    print("-" * 60)
-    print(f"{'ID':<12} {'Label':<30} {'Status':<15}")
-    print("-" * 60)
-    for fw in firewalls:
-        print(f"{fw['id']:<12} {fw['label']:<30} {fw['status']:<15}")
-    print("-" * 60)
+    rows = [(fw["id"], fw["label"], fw["status"]) for fw in firewalls]
+    _print_table("Available firewalls:", ["ID", "Label", "Status"], rows)
 
 
 def _handle_lke_list_command():
@@ -46,14 +59,21 @@ def _handle_lke_list_command():
         print("No LKE clusters found in your Linode account.")
         return
 
-    print("\nAvailable LKE clusters:")
-    print("-" * 80)
-    print(f"{'ID':<10} {'Label':<28} {'Region':<14} {'Tier':<12} {'Status':<12}")
-    print("-" * 80)
-    for c in clusters:
-        tier = "enterprise" if c.get("tier") == "enterprise" else "standard"
-        print(f"{c['id']:<10} {c['label']:<28} {c['region']:<14} {tier:<12} {c['status']:<12}")
-    print("-" * 80)
+    rows = [
+        (
+            c["id"],
+            c["label"],
+            c["region"],
+            "enterprise" if c.get("tier") == "enterprise" else "standard",
+            c["status"],
+        )
+        for c in clusters
+    ]
+    _print_table(
+        "Available LKE clusters:",
+        ["ID", "Label", "Region", "Tier", "Status"],
+        rows,
+    )
 
 
 def _handle_lke_command(args):
@@ -69,11 +89,14 @@ def _handle_lke_command(args):
     )
 
 
-def _resolve_config_from_file(args_label):
+def _resolve_config_from_file(args_label, quiet=False):
     """Load config from file, using args_label as fallback."""
     firewall_id, label = load_config()
     if label is None:
         label = args_label
+    if not quiet:
+        print(f"Using saved firewall: ID {firewall_id}, label '{label}' "
+              f"(from {CONFIG_FILE_PATH})")
     return firewall_id, label
 
 
@@ -124,9 +147,12 @@ def _create_parser():
     parser.add_argument("-l", "--list", action="store_true",
                         help="List available firewalls (or LKE clusters with --lke) and exit.")
     parser.add_argument("--lke", action="store_true",
-                        help="Target LKE/LKE-E Control Plane ACLs instead of firewall rules. "
+                        help="Target LKE/LKE-E Control Plane ACLs only; skip firewall rules. "
                              "Adds (or removes with -r) your current public IP to every "
                              "cluster's ACL.")
+    parser.add_argument("--no-lke", action="store_true",
+                        help="Skip the default LKE/LKE-E Control Plane ACL update. "
+                             "By default, acc-fwu updates both firewall rules and LKE ACLs.")
     parser.add_argument("-q", "--quiet", action="store_true",
                         help="Suppress output messages (useful for cron/scripting).")
     parser.add_argument("--dry-run", action="store_true",
@@ -141,7 +167,7 @@ def _resolve_firewall_config(args):
         return _resolve_config_from_args(args)
 
     try:
-        return _resolve_config_from_file(args.label)
+        return _resolve_config_from_file(args.label, quiet=args.quiet)
     except FileNotFoundError:
         return _resolve_config_interactive(args)
 
@@ -176,6 +202,15 @@ def main():
 
         firewall_id, label = _resolve_firewall_config(args)
         _execute_firewall_operation(args, firewall_id, label)
+
+        if not args.no_lke:
+            update_all_lke_acls(
+                debug=args.debug,
+                quiet=args.quiet,
+                dry_run=args.dry_run,
+                remove=args.remove,
+                implicit=True,
+            )
 
     except (ValueError, EOFError, KeyboardInterrupt) as e:
         if not args.quiet:

--- a/src/acc_fwu/lke.py
+++ b/src/acc_fwu/lke.py
@@ -226,7 +226,7 @@ def _process_cluster(cluster, ip_with_mask, remove, debug, quiet, dry_run, heade
     return "changed"
 
 
-def update_all_lke_acls(debug=False, quiet=False, dry_run=False, remove=False):
+def update_all_lke_acls(debug=False, quiet=False, dry_run=False, remove=False, implicit=False):
     """
     Add (or remove) the current public IP on every LKE/LKE-E Control Plane ACL.
 
@@ -235,6 +235,9 @@ def update_all_lke_acls(debug=False, quiet=False, dry_run=False, remove=False):
         quiet (bool): Suppress informational output.
         dry_run (bool): Show the planned changes without calling the PUT API.
         remove (bool): Remove the IP instead of adding it.
+        implicit (bool): True when this call is part of the default firewall+LKE
+            run (i.e., user did not pass ``--lke`` explicitly). Suppresses the
+            "No LKE clusters found" notice so users without LKE see no noise.
 
     Returns:
         dict: Summary counts: ``changed``, ``unchanged``, ``failed``, ``total``.
@@ -243,7 +246,7 @@ def update_all_lke_acls(debug=False, quiet=False, dry_run=False, remove=False):
     clusters = list_lke_clusters()
 
     if not clusters:
-        if not quiet:
+        if not quiet and not implicit:
             print("No LKE clusters found in your Linode account.")
         return {"changed": 0, "unchanged": 0, "failed": 0, "total": 0}
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,7 +19,10 @@ class TestCliBasicOperations:
         monkeypatch.setattr("acc_fwu.cli.validate_firewall_id", mock_validate_firewall_id)
         monkeypatch.setattr("acc_fwu.cli.validate_label", mock_validate_label)
 
-        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--firewall_id', '12345', '--label', 'Test-Label'])
+        monkeypatch.setattr(
+            sys, 'argv',
+            ['acc-fwu', '--firewall_id', '12345', '--label', 'Test-Label', '--no-lke'],
+        )
 
         main()
 
@@ -36,7 +39,7 @@ class TestCliBasicOperations:
         monkeypatch.setattr("acc_fwu.cli.load_config", mock_load_config)
         monkeypatch.setattr("acc_fwu.cli.update_firewall_rule", mock_update_firewall_rule)
 
-        monkeypatch.setattr(sys, 'argv', ['acc-fwu'])
+        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--no-lke'])
 
         main()
 
@@ -50,7 +53,7 @@ class TestCliBasicOperations:
         mock_load_config = mock.MagicMock(side_effect=FileNotFoundError)
 
         monkeypatch.setattr("acc_fwu.cli.load_config", mock_load_config)
-        monkeypatch.setattr(sys, 'argv', ['acc-fwu'])
+        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--no-lke'])
 
         with pytest.raises(SystemExit) as exc_info:
             main()
@@ -66,7 +69,7 @@ class TestCliBasicOperations:
         monkeypatch.setattr("acc_fwu.cli.load_config", mock_load_config)
         monkeypatch.setattr("acc_fwu.cli.update_firewall_rule", mock_update_firewall_rule)
 
-        monkeypatch.setattr(sys, 'argv', ['acc-fwu'])
+        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--no-lke'])
 
         main()
 
@@ -75,6 +78,36 @@ class TestCliBasicOperations:
         mock_update_firewall_rule.assert_called_once_with(
             "12345", "Default-Label", debug=False, quiet=False, dry_run=False, add_ip=False
         )
+
+    def test_main_prints_active_firewall_from_config(self, monkeypatch, capsys):
+        """Test CLI prints which saved firewall is being used."""
+        mock_load_config = mock.MagicMock(return_value=("12345", "Loaded-Label"))
+        mock_update_firewall_rule = mock.MagicMock()
+
+        monkeypatch.setattr("acc_fwu.cli.load_config", mock_load_config)
+        monkeypatch.setattr("acc_fwu.cli.update_firewall_rule", mock_update_firewall_rule)
+        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--no-lke'])
+
+        main()
+
+        captured = capsys.readouterr()
+        assert "Using saved firewall" in captured.out
+        assert "12345" in captured.out
+        assert "Loaded-Label" in captured.out
+
+    def test_main_quiet_suppresses_active_firewall_notice(self, monkeypatch, capsys):
+        """Quiet mode should not print the 'Using saved firewall' notice."""
+        mock_load_config = mock.MagicMock(return_value=("12345", "Loaded-Label"))
+        mock_update_firewall_rule = mock.MagicMock()
+
+        monkeypatch.setattr("acc_fwu.cli.load_config", mock_load_config)
+        monkeypatch.setattr("acc_fwu.cli.update_firewall_rule", mock_update_firewall_rule)
+        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--no-lke', '-q'])
+
+        main()
+
+        captured = capsys.readouterr()
+        assert "Using saved firewall" not in captured.out
 
 
 class TestCliRemoveOperation:
@@ -92,7 +125,10 @@ class TestCliRemoveOperation:
         monkeypatch.setattr("acc_fwu.cli.validate_firewall_id", mock_validate_firewall_id)
         monkeypatch.setattr("acc_fwu.cli.validate_label", mock_validate_label)
 
-        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--firewall_id', '12345', '--label', 'Test-Label', '-r'])
+        monkeypatch.setattr(
+            sys, 'argv',
+            ['acc-fwu', '--firewall_id', '12345', '--label', 'Test-Label', '-r', '--no-lke'],
+        )
 
         main()
 
@@ -117,7 +153,10 @@ class TestCliNewOptions:
         monkeypatch.setattr("acc_fwu.cli.validate_firewall_id", mock_validate_firewall_id)
         monkeypatch.setattr("acc_fwu.cli.validate_label", mock_validate_label)
 
-        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--firewall_id', '12345', '--label', 'Test-Label', '-q'])
+        monkeypatch.setattr(
+            sys, 'argv',
+            ['acc-fwu', '--firewall_id', '12345', '--label', 'Test-Label', '-q', '--no-lke'],
+        )
 
         main()
 
@@ -138,7 +177,10 @@ class TestCliNewOptions:
         monkeypatch.setattr("acc_fwu.cli.validate_firewall_id", mock_validate_firewall_id)
         monkeypatch.setattr("acc_fwu.cli.validate_label", mock_validate_label)
 
-        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--firewall_id', '12345', '--label', 'Test-Label', '--dry-run'])
+        monkeypatch.setattr(
+            sys, 'argv',
+            ['acc-fwu', '--firewall_id', '12345', '--label', 'Test-Label', '--dry-run', '--no-lke'],
+        )
 
         main()
 
@@ -160,7 +202,7 @@ class TestCliNewOptions:
         monkeypatch.setattr("acc_fwu.cli.validate_firewall_id", mock_validate_firewall_id)
         monkeypatch.setattr("acc_fwu.cli.validate_label", mock_validate_label)
 
-        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--firewall_id', '12345', '-d'])
+        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--firewall_id', '12345', '-d', '--no-lke'])
 
         main()
 
@@ -173,7 +215,7 @@ class TestCliNewOptions:
         mock_load_config = mock.MagicMock(side_effect=FileNotFoundError)
 
         monkeypatch.setattr("acc_fwu.cli.load_config", mock_load_config)
-        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '-q'])
+        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '-q', '--no-lke'])
 
         with pytest.raises(SystemExit) as exc_info:
             main()
@@ -220,7 +262,7 @@ class TestCliErrorHandling:
 
         monkeypatch.setattr("acc_fwu.cli.load_config", mock_load_config)
         monkeypatch.setattr("acc_fwu.cli.update_firewall_rule", mock_update_firewall_rule)
-        monkeypatch.setattr(sys, 'argv', ['acc-fwu'])
+        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--no-lke'])
 
         with pytest.raises(SystemExit) as exc_info:
             main()
@@ -238,7 +280,7 @@ class TestCliErrorHandling:
 
         monkeypatch.setattr("acc_fwu.cli.load_config", mock_load_config)
         monkeypatch.setattr("acc_fwu.cli.update_firewall_rule", mock_update_firewall_rule)
-        monkeypatch.setattr(sys, 'argv', ['acc-fwu'])
+        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--no-lke'])
 
         with pytest.raises(SystemExit) as exc_info:
             main()
@@ -257,7 +299,7 @@ class TestCliErrorHandling:
 
         monkeypatch.setattr("acc_fwu.cli.load_config", mock_load_config)
         monkeypatch.setattr("acc_fwu.cli.update_firewall_rule", mock_update_firewall_rule)
-        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--debug'])
+        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--debug', '--no-lke'])
 
         # With --debug, the exception should be re-raised, not caught
         with pytest.raises(RuntimeError, match="Unexpected error"):
@@ -296,7 +338,10 @@ class TestCliAddFlag:
         monkeypatch.setattr("acc_fwu.cli.validate_firewall_id", mock_validate_firewall_id)
         monkeypatch.setattr("acc_fwu.cli.validate_label", mock_validate_label)
 
-        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--firewall_id', '12345', '--label', 'Test', '-a'])
+        monkeypatch.setattr(
+            sys, 'argv',
+            ['acc-fwu', '--firewall_id', '12345', '--label', 'Test', '-a', '--no-lke'],
+        )
 
         main()
 
@@ -312,7 +357,7 @@ class TestCliAddFlag:
         monkeypatch.setattr("acc_fwu.cli.load_config", mock_load_config)
         monkeypatch.setattr("acc_fwu.cli.update_firewall_rule", mock_update_firewall_rule)
 
-        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--add'])
+        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--add', '--no-lke'])
 
         main()
 
@@ -386,7 +431,7 @@ class TestCliInteractiveSelection:
         monkeypatch.setattr("acc_fwu.cli.save_config", mock_save_config)
         monkeypatch.setattr("acc_fwu.cli.update_firewall_rule", mock_update_firewall_rule)
 
-        monkeypatch.setattr(sys, 'argv', ['acc-fwu'])
+        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--no-lke'])
 
         main()
 
@@ -408,7 +453,7 @@ class TestCliInteractiveSelection:
         monkeypatch.setattr("acc_fwu.cli.save_config", mock_save_config)
         monkeypatch.setattr("acc_fwu.cli.update_firewall_rule", mock_update_firewall_rule)
 
-        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--dry-run'])
+        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--dry-run', '--no-lke'])
 
         main()
 
@@ -426,7 +471,7 @@ class TestCliInteractiveSelection:
         monkeypatch.setattr("acc_fwu.cli.load_config", mock_load_config)
         monkeypatch.setattr("acc_fwu.cli.select_firewall", mock_select_firewall)
 
-        monkeypatch.setattr(sys, 'argv', ['acc-fwu'])
+        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--no-lke'])
 
         with pytest.raises(SystemExit) as exc_info:
             main()
@@ -531,3 +576,85 @@ class TestCliLkeFlag:
 
         mock_update.assert_called_once()
         mock_load.assert_not_called()
+
+
+class TestCliDefaultLkeBehavior:
+    """Tests for the default-on LKE update that runs alongside firewall updates."""
+
+    def test_firewall_run_also_updates_lke_by_default(self, monkeypatch):
+        """Without --lke/--no-lke, a firewall update also calls update_all_lke_acls."""
+        mock_load = mock.MagicMock(return_value=("12345", "Label"))
+        mock_update_fw = mock.MagicMock()
+        mock_update_lke = mock.MagicMock()
+
+        monkeypatch.setattr("acc_fwu.cli.load_config", mock_load)
+        monkeypatch.setattr("acc_fwu.cli.update_firewall_rule", mock_update_fw)
+        monkeypatch.setattr("acc_fwu.cli.update_all_lke_acls", mock_update_lke)
+        monkeypatch.setattr(sys, "argv", ["acc-fwu"])
+
+        main()
+
+        mock_update_fw.assert_called_once()
+        mock_update_lke.assert_called_once_with(
+            debug=False, quiet=False, dry_run=False, remove=False, implicit=True,
+        )
+
+    def test_no_lke_flag_skips_lke_update(self, monkeypatch):
+        """--no-lke should skip the implicit LKE ACL update."""
+        mock_load = mock.MagicMock(return_value=("12345", "Label"))
+        mock_update_fw = mock.MagicMock()
+        mock_update_lke = mock.MagicMock()
+
+        monkeypatch.setattr("acc_fwu.cli.load_config", mock_load)
+        monkeypatch.setattr("acc_fwu.cli.update_firewall_rule", mock_update_fw)
+        monkeypatch.setattr("acc_fwu.cli.update_all_lke_acls", mock_update_lke)
+        monkeypatch.setattr(sys, "argv", ["acc-fwu", "--no-lke"])
+
+        main()
+
+        mock_update_fw.assert_called_once()
+        mock_update_lke.assert_not_called()
+
+    def test_remove_flag_propagates_to_implicit_lke_update(self, monkeypatch):
+        """acc-fwu -r should remove IP from both firewall and LKE ACLs by default."""
+        mock_load = mock.MagicMock(return_value=("12345", "Label"))
+        mock_remove_fw = mock.MagicMock()
+        mock_update_lke = mock.MagicMock()
+
+        monkeypatch.setattr("acc_fwu.cli.load_config", mock_load)
+        monkeypatch.setattr("acc_fwu.cli.remove_firewall_rule", mock_remove_fw)
+        monkeypatch.setattr("acc_fwu.cli.update_all_lke_acls", mock_update_lke)
+        monkeypatch.setattr(sys, "argv", ["acc-fwu", "-r"])
+
+        main()
+
+        mock_remove_fw.assert_called_once()
+        mock_update_lke.assert_called_once_with(
+            debug=False, quiet=False, dry_run=False, remove=True, implicit=True,
+        )
+
+
+class TestCliListTableFormatting:
+    """Tests for dynamic column sizing in --list output."""
+
+    def test_firewall_list_columns_accommodate_long_labels(self, monkeypatch, capsys):
+        """Labels longer than the default width must not corrupt column alignment."""
+        long_label = "resilio-sync-jumpbox-fw-e4e83e29"  # 32 chars
+        mock_list = mock.MagicMock(return_value=[
+            {"id": 243627, "label": "default", "status": "enabled"},
+            {"id": 3709226, "label": long_label, "status": "enabled"},
+        ])
+        monkeypatch.setattr("acc_fwu.cli.list_firewalls", mock_list)
+        monkeypatch.setattr(sys, "argv", ["acc-fwu", "--list"])
+
+        main()
+
+        captured = capsys.readouterr()
+        # Each row should align: find the line with the long label and
+        # ensure the status column follows after the full label.
+        for line in captured.out.splitlines():
+            if long_label in line:
+                assert line.index("enabled") > line.index(long_label) + len(long_label)
+                break
+        else:
+            pytest.fail(f"long label {long_label!r} not found in output:\n{captured.out}")


### PR DESCRIPTION
## Summary

Three UX improvements surfaced during this release cycle:

- **LKE auto-updates**: firewall-rule runs now also sync your public IP into every LKE / LKE-E Control Plane ACL. Opt out via \`--no-lke\`; \`--lke\` still means "LKE only".
- **Active firewall indicator**: when the firewall is loaded from \`~/.acc-fwu-config\`, \`acc-fwu\` now prints \`Using saved firewall: ID 12345, label 'MyIP' (from ~/.acc-fwu-config)\` so you can see which firewall will be touched. Suppressed under \`--quiet\`.
- **Dynamic \`--list\` tables**: both the firewall and LKE cluster list tables now auto-size each column to the widest value, so 32-char labels like \`resilio-sync-jumpbox-fw-e4e83e29\` no longer break \`Status\` alignment.

### Behavior change note

The default-on LKE update is a **silent behavior change** for anyone whose scheduled \`acc-fwu\` cron runs on an account with LKE clusters — those clusters' Control Plane ACLs will now start being synced. Users who want the prior firewall-only behavior should add \`--no-lke\` to their cron invocation.

### Implementation

- \`update_all_lke_acls()\` gains \`implicit=False\`. When \`main()\` calls it after a firewall operation with \`implicit=True\`, the "No LKE clusters found" message is suppressed (no noise for accounts without LKE).
- New \`_print_table(title, headers, rows)\` helper drives both list commands.
- Docs: README gets a v0.3.1 changelog entry; CLAUDE.md updated for the new architecture.

## Test plan

- [x] \`pytest\` — 111 tests pass (was 105; +6 for new behavior and table formatting)
- [x] \`flake8\` — clean (both E9/F63/F7/F82 and max-complexity passes)
- [x] \`acc-fwu -h\` shows both \`--lke\` and \`--no-lke\` with refreshed help text
- [ ] CI green on this PR before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)