### PR TITLE
docs: post-v0.3.1 audit — sync structure, test catalog, and cron example

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -126,12 +126,14 @@ acc-firewall_updater/
 │   └── acc_fwu/
 │       ├── __init__.py      # Package initializer
 │       ├── cli.py           # CLI entry point
-│       └── firewall.py      # Core firewall logic
+│       ├── firewall.py      # Core firewall logic
+│       └── lke.py           # LKE / LKE-E Control Plane ACL logic
 ├── tests/
 │   ├── test_cli.py          # CLI tests
-│   └── test_firewall.py     # Firewall logic tests
+│   ├── test_firewall.py     # Firewall logic tests
+│   └── test_lke.py          # LKE ACL logic tests
 ├── setup.py                  # Package setup configuration
-├── pyproject.toml            # Build system configuration
+├── pyproject.toml            # Build system configuration (PEP 517 isolation)
 ├── requirements.txt          # Runtime dependencies
 ├── README.md                 # Project documentation
 ├── BUILD.md                  # This file

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ Internal helpers (prefixed with `_`):
 - `_no_changes_needed(...)` - Checks if IP already exists in add mode
 - `_print_dry_run_message(...)` / `_print_result_message(...)` - Output helpers
 
-### Important Constants (firewall.py:7-17)
+### Important Constants (firewall.py:8-17)
 ```python
 REQUESTS_TIMEOUT = 5
 CONFIG_FILE_PATH = "~/.acc-fwu-config"
@@ -114,7 +114,7 @@ LABEL_PATTERN = re.compile(r"^[a-zA-Z0-9_-]{1,32}$")
 IPV4_PATTERN = re.compile(r"^(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)$")
 ```
 
-### Error Handling Pattern (cli.py:133-149)
+### Error Handling Pattern (cli.py:215-223)
 - `ValueError`, `EOFError`, `KeyboardInterrupt` → Error message to stderr, exit code 1
 - `FileNotFoundError` → Handled internally by `_resolve_firewall_config` (triggers interactive selection)
 - General exceptions → "Error" message to stderr (or re-raised in debug mode)
@@ -135,15 +135,25 @@ Tests are organized by class with descriptive names:
 - `TestSelectFirewall` - Interactive firewall selection
 
 **test_cli.py** (CLI integration tests):
-- `TestCliBasicOperations` - Basic CLI operations
+- `TestCliBasicOperations` - Basic CLI operations (including active-firewall-from-config print)
 - `TestCliRemoveOperation` - Remove flag tests
-- `TestCliNewOptions` - Dry-run and quiet mode tests
+- `TestCliNewOptions` - Dry-run, quiet, and debug mode tests
 - `TestCliValidation` - Input validation via CLI
 - `TestCliErrorHandling` - Error handling and debug mode
 - `TestCliVersion` - Version flag tests
 - `TestCliAddFlag` - Add mode (--add flag) tests
 - `TestCliListFlag` - List firewalls (--list flag) tests
 - `TestCliInteractiveSelection` - Interactive selection tests
+- `TestCliLkeFlag` - LKE-only mode (--lke flag) tests
+- `TestCliDefaultLkeBehavior` - Default-on LKE update and --no-lke opt-out
+- `TestCliListTableFormatting` - Dynamic column widths in --list output
+
+**test_lke.py** (unit tests for LKE / LKE-E ACL logic):
+- `TestListLkeClusters` - Paginated cluster listing, LKE-E `tier` detection
+- `TestGetLkeAcl` - ACL fetch normalisation (missing fields, null addresses)
+- `TestPutLkeAcl` - ACL envelope wrapping, error surfacing
+- `TestApplyIpToAcl` - Add/remove idempotency and address-set manipulation
+- `TestUpdateAllLkeAcls` - Orchestrator: per-cluster failure isolation, implicit-mode silence, summary counts
 
 ### Mocking Strategy
 All external dependencies are mocked:

--- a/README.md
+++ b/README.md
@@ -237,11 +237,14 @@ Clusters whose ACL is disabled will still have the address stored, but `acc-fwu`
 
 ### Cron Job Example
 
-To automatically update your firewall rules every hour:
+To automatically update your firewall rules (and, since v0.3.1, any LKE / LKE-E Control Plane ACLs) every hour:
 
 ```bash
-# Update firewall rules every hour
+# Update firewall rules + LKE ACLs every hour
 0 * * * * /usr/local/bin/acc-fwu --quiet
+
+# Firewall only (skip LKE step)
+0 * * * * /usr/local/bin/acc-fwu --quiet --no-lke
 ```
 
 **Important**: Before using `--quiet` mode, you must have a valid configuration file (`~/.acc-fwu-config`) with your `firewall_id` and `label`. Interactive firewall selection is not available in quiet mode. Run `acc-fwu` interactively first to set up your configuration.


### PR DESCRIPTION
## Summary

Post-release documentation audit after v0.3.1 shipped. Non-code drift caught by \`/document-release\`:

- **CLAUDE.md**: refresh the test-class catalogs (add \`test_lke.py\` classes and the three new \`test_cli.py\` classes: \`TestCliLkeFlag\`, \`TestCliDefaultLkeBehavior\`, \`TestCliListTableFormatting\`); fix two stale line-number references that drifted when \`main()\` grew the implicit LKE dispatch.
- **BUILD.md**: add \`src/acc_fwu/lke.py\` and \`tests/test_lke.py\` to the project structure tree; note \`pyproject.toml\` now drives PEP 517 build isolation.
- **README.md**: rewrite the cron-job example so the comment reflects the v0.3.1 default (firewall + LKE ACLs both refresh); add a firewall-only \`--no-lke\` variant.

No functional code changes. No CHANGELOG/VERSION files in this repo, so those skill steps are skipped. No cross-doc contradictions remain.

## Test plan

- [x] No test changes needed — docs only
- [x] \`git diff\` clean: 3 files, 24 insertions / 9 deletions
- [ ] CI green (dependency-review + CodeQL + doc-adjacent checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code) via \`/document-release\`