### PR TITLE
feat: automate Managed Database allow_list updates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,8 +311,12 @@ The tool uses the Linode API v4:
   list (does not mutate the input) plus `(changed, already_in_state)` flags.
 - `update_all_database_acls(debug, quiet, dry_run, remove, implicit=False)` -
   Orchestrator. Iterates databases and applies `_apply_ip_to_allow_list` to
-  add/remove the current public IP. Per-database PUT failures and unsupported
-  engines are logged and counted (`failed`) but do not abort the batch. When
+  add/remove the current public IP. Per-database PUT failures, unsupported
+  engines, and **VPC-attached databases** (`private_network` is non-null) are
+  logged and counted (`failed`) but do not abort the batch. We skip VPC-attached
+  databases because the public IP we detect from ipify cannot reach a VPC-only
+  endpoint — even with `public_access=true`, allow_list still gates external
+  connections, but they will not originate from the user's public IP. When
   `implicit=True` (the default firewall+LKE+database path driven by `main()`),
   the "No managed databases found" notice is suppressed so users without any
   databases see no extra output. Returns

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ This file provides guidance for AI assistants working with the `acc-fwu` (Akamai
 - Interactive firewall selection (lists available firewalls)
 - Add mode for multiple IP addresses (travel use case)
 - LKE / LKE-E Control Plane ACL automation runs by default alongside firewall updates (`--no-lke` to skip, `--lke` for LKE-only mode)
+- Managed Database (MySQL/PostgreSQL) `allow_list` automation runs by default alongside firewall updates (`--no-database` to skip, `--database` for database-only mode)
 - Prints the active firewall ID/label when loaded from config so the user sees which firewall is being touched
 
 ## Codebase Structure
@@ -32,11 +33,13 @@ acc-firewall_updater/
 │   ├── cli.py             # CLI entry point (argparse, main function)
 │   ├── firewall.py        # Core business logic (API calls, validation)
 │   ├── lke.py             # LKE/LKE-E Control Plane ACL automation
+│   ├── databases.py       # Managed Database (MySQL/PostgreSQL) allow_list automation
 │   └── output.py          # Shared output formatters used by every deployment type
 ├── tests/                 # Test suite
 │   ├── test_cli.py        # CLI integration tests
 │   ├── test_firewall.py   # Unit tests for firewall logic
 │   ├── test_lke.py        # Unit tests for LKE ACL logic
+│   ├── test_databases.py  # Unit tests for managed database allow_list logic
 │   └── test_output.py     # Unit tests for the shared output module
 ├── setup.py               # Package configuration (uses setuptools_scm)
 ├── pyproject.toml         # Build system config
@@ -71,18 +74,21 @@ python -m build
 ## Key Code Patterns
 
 ### Architecture
-- **`cli.py`**: Handles argument parsing and orchestrates calls to `firewall.py` / `lke.py`. Refactored into small helper functions:
+- **`cli.py`**: Handles argument parsing and orchestrates calls to `firewall.py` / `lke.py` / `databases.py`. Refactored into small helper functions:
   - `_create_parser()` - Builds the argparse parser
-  - `_print_table(title, headers, rows)` - Renders a table with columns auto-sized to the widest cell (used by both firewall and LKE list commands)
+  - `_print_table(title, headers, rows)` - Renders a table with columns auto-sized to the widest cell (used by firewall, LKE, and database list commands)
   - `_handle_list_command(debug)` - Handles `--list` flag for firewalls
   - `_handle_lke_list_command()` / `_handle_lke_command(args)` - LKE-specific list and update dispatch
+  - `_handle_database_list_command()` / `_handle_database_command(args)` - Managed-database list and update dispatch
   - `_resolve_firewall_config(args)` - Resolves config from args, file, or interactive selection
   - `_resolve_config_from_args(args)` / `_resolve_config_from_file(label, quiet)` / `_resolve_config_interactive(args)` - Config resolution helpers. `_resolve_config_from_file` prints the active firewall ID/label unless `quiet`.
   - `_execute_firewall_operation(args, firewall_id, label)` - Dispatches update or remove
-  - `main()` - After the firewall operation, calls `update_all_lke_acls(..., implicit=True)` unless `--no-lke` is set
+  - `_run_implicit_batch_updates(args)` - After the firewall op, calls `update_all_lke_acls(..., implicit=True)` unless `--no-lke`, then `update_all_database_acls(..., implicit=True)` unless `--no-database`
+  - `main()` - Top-level dispatcher
 - **`firewall.py`**: Contains all business logic, API interactions, and validation
 - **`lke.py`**: LKE/LKE-E cluster enumeration and Control Plane ACL mutation
-- **`output.py`**: Shared formatters that every deployment type (firewall, LKE, any future type such as databases) uses so their output looks identical — target identifier: `<type> '<label>' (ID: <id>)`; lifecycle lines: preamble, result, noop, dry-run, skip, summary
+- **`databases.py`**: Managed Database (MySQL/PostgreSQL) enumeration and `allow_list` mutation
+- **`output.py`**: Shared formatters that every deployment type (firewall, LKE, databases, any future type) uses so their output looks identical — target identifier: `<type> '<label>' (ID: <id>)`; lifecycle lines: preamble, result, noop, dry-run, skip, summary
 
 ### Validation Functions (firewall.py)
 All inputs are validated before use:
@@ -149,6 +155,8 @@ Tests are organized by class with descriptive names:
 - `TestCliInteractiveSelection` - Interactive selection tests
 - `TestCliLkeFlag` - LKE-only mode (--lke flag) tests
 - `TestCliDefaultLkeBehavior` - Default-on LKE update and --no-lke opt-out
+- `TestCliDatabaseFlag` - Database-only mode (--database flag) tests
+- `TestCliDefaultDatabaseBehavior` - Default-on database update and --no-database opt-out
 - `TestCliListTableFormatting` - Dynamic column widths in --list output
 
 **test_lke.py** (unit tests for LKE / LKE-E ACL logic):
@@ -157,6 +165,12 @@ Tests are organized by class with descriptive names:
 - `TestPutLkeAcl` - ACL envelope wrapping, error surfacing
 - `TestApplyIpToAcl` - Add/remove idempotency and address-set manipulation
 - `TestUpdateAllLkeAcls` - Orchestrator: per-cluster failure isolation, implicit-mode silence, summary counts
+
+**test_databases.py** (unit tests for managed database `allow_list` logic):
+- `TestListDatabases` - Paginated listing across engines, `allow_list` and `engine` fields
+- `TestPutDatabaseAllowList` - Engine-specific URL routing (`mysql`/`postgresql`), error surfacing
+- `TestApplyIpToAllowList` - Add/remove idempotency, no in-place mutation
+- `TestUpdateAllDatabaseAcls` - Orchestrator: per-database failure isolation, unsupported-engine skip, implicit-mode silence, summary counts
 
 ### Mocking Strategy
 All external dependencies are mocked:
@@ -260,8 +274,10 @@ The tool uses the Linode API v4:
   - `/networking/firewalls/{firewall_id}/rules` - Manage rules (GET/PUT)
   - `/lke/clusters` - List all LKE and LKE-E clusters (GET, paginated)
   - `/lke/clusters/{cluster_id}/control_plane_acl` - Manage Control Plane ACL (GET/PUT)
+  - `/databases/instances` - List all managed databases regardless of engine (GET, paginated)
+  - `/databases/{engine}/instances/{database_id}` - Update database `allow_list` (PUT); `engine` is `mysql` or `postgresql`
 - Authentication: Bearer token from Linode CLI config
-- Methods: GET (fetch firewalls/rules/clusters/ACL), PUT (update rules, update ACL)
+- Methods: GET (fetch firewalls/rules/clusters/ACL/databases), PUT (update rules, update ACL, update allow_list)
 
 ### LKE Module (`lke.py`)
 
@@ -278,6 +294,28 @@ The tool uses the Linode API v4:
   (`failed`) but do not abort the batch. When `implicit=True` (the default
   firewall+LKE path driven by `main()`), the "No LKE clusters found" notice is
   suppressed so users without any clusters see no extra output. Returns
+  `{"changed", "unchanged", "failed", "total"}`.
+
+### Databases Module (`databases.py`)
+
+- `SUPPORTED_DB_ENGINES = ("mysql", "postgresql")` - engines whose `allow_list`
+  this tool knows how to update; other engines surfaced by the listing endpoint
+  are reported as a per-database `failed` skip.
+- `list_databases()` - Paginated list of every managed database on the account
+  via `/databases/instances`. The list response already contains `allow_list`,
+  so the orchestrator does not need a per-database GET.
+- `put_database_allow_list(database_id, engine, allow_list, headers=None,
+  debug=False)` - PUTs to `/databases/{engine}/instances/{database_id}` with the
+  `{"allow_list": [...]}` body. The new list overwrites the existing one.
+- `_apply_ip_to_allow_list(allow_list, ip_with_mask, remove)` - Returns a fresh
+  list (does not mutate the input) plus `(changed, already_in_state)` flags.
+- `update_all_database_acls(debug, quiet, dry_run, remove, implicit=False)` -
+  Orchestrator. Iterates databases and applies `_apply_ip_to_allow_list` to
+  add/remove the current public IP. Per-database PUT failures and unsupported
+  engines are logged and counted (`failed`) but do not abort the batch. When
+  `implicit=True` (the default firewall+LKE+database path driven by `main()`),
+  the "No managed databases found" notice is suppressed so users without any
+  databases see no extra output. Returns
   `{"changed", "unchanged", "failed", "total"}`.
 
 ## File Locations

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A tool to automatically update the [Akamai Connected Cloud (ACC) / Linode](https
 - **Interactive firewall selection** - List and choose from available firewalls
 - **Add mode** - Accumulate multiple IP addresses (ideal for traveling)
 - **LKE Control Plane ACL automation** - Every run also syncs your public IP into every LKE and LKE-E cluster's Control Plane ACL (opt-out with `--no-lke`; use `--lke` for LKE-only mode)
+- **Managed Database allow_list automation** - Every run also syncs your public IP into every MySQL/PostgreSQL Managed Database `allow_list` (opt-out with `--no-database`; use `--database` for database-only mode)
 - **Active firewall indicator** - When the config file is used, `acc-fwu` prints the firewall ID and label it's operating on
 
 ## Prerequisites
@@ -83,11 +84,12 @@ This will:
 2. Print the active firewall (for example `Using saved firewall: ID 123456, label 'My-IP' (from ~/.acc-fwu-config)`).
 3. Update the firewall rule with your current public IP address.
 4. Sync your current public IP into every LKE / LKE-E Control Plane ACL in your account. Pass `--no-lke` to skip this step.
+5. Sync your current public IP into every Managed Database (MySQL/PostgreSQL) `allow_list` in your account. Pass `--no-database` to skip this step.
 
 ### Command-Line Options
 
 ```
-usage: acc-fwu [-h] [--firewall_id FIREWALL_ID] [--label LABEL] [-d] [-r] [-a] [-l] [--lke] [--no-lke] [-q] [--dry-run] [-v]
+usage: acc-fwu [-h] [--firewall_id FIREWALL_ID] [--label LABEL] [-d] [-r] [-a] [-l] [--lke] [--no-lke] [--database] [--no-database] [-q] [--dry-run] [-v]
 
 Create, update, or remove Akamai Connected Cloud (Linode) firewall rules with your current IP address.
 
@@ -99,11 +101,15 @@ options:
   -d, --debug           Enable debug mode to show existing rules data.
   -r, --remove          Remove the specified rules from the firewall.
   -a, --add             Add IP to existing rules instead of replacing (useful for multiple locations).
-  -l, --list            List available firewalls (or LKE clusters with --lke) and exit.
+  -l, --list            List available firewalls (or LKE clusters with --lke, or managed databases with --database) and exit.
   --lke                 Target LKE/LKE-E Control Plane ACLs only; skip firewall rules.
                         Adds (or removes with -r) your current public IP to every cluster's ACL.
   --no-lke              Skip the default LKE/LKE-E Control Plane ACL update.
-                        By default, acc-fwu updates both firewall rules and LKE ACLs.
+                        By default, acc-fwu updates firewall rules, LKE ACLs, and managed database allow_lists.
+  --database            Target managed database allow_lists only; skip firewall rules.
+                        Adds (or removes with -r) your current public IP to every managed database's allow_list.
+  --no-database         Skip the default managed database allow_list update.
+                        By default, acc-fwu updates firewall rules, LKE ACLs, and managed database allow_lists.
   -q, --quiet           Suppress output messages (useful for cron/scripting).
   --dry-run             Show what would be done without making any changes.
   -v, --version         show program's version number and exit
@@ -235,16 +241,54 @@ acc-fwu --lke --remove
 
 Clusters whose ACL is disabled will still have the address stored, but `acc-fwu` prints a warning — the entry will not be enforced until you enable the ACL. Failures on individual clusters are logged and counted in the final summary but do not abort the run.
 
-### Cron Job Example
+### Managed Database `allow_list`
 
-To automatically update your firewall rules (and, since v0.3.1, any LKE / LKE-E Control Plane ACLs) every hour:
+`acc-fwu` automates [`allow_list`](https://techdocs.akamai.com/linode-api/reference/put-databases-mysql-instance) updates for every Linode Managed Database (MySQL and PostgreSQL) in your account. For each database it appends (or removes) your public IP, preserving any other entries already present.
+
+**Default behaviour:** every firewall update also syncs your IP into each managed database's `allow_list`. Accounts with no databases see no extra output. Pass `--no-database` to skip it, or `--database` for database-only mode.
+
+**List all managed databases:**
 
 ```bash
-# Update firewall rules + LKE ACLs every hour
+acc-fwu --database --list
+```
+
+**Skip the database step while still updating firewall rules:**
+
+```bash
+acc-fwu --no-database
+```
+
+**Database-only mode (skip firewall rule updates entirely):**
+
+```bash
+acc-fwu --database
+```
+
+**Preview changes:**
+
+```bash
+acc-fwu --database --dry-run
+```
+
+**Remove your current IP from every database's allow_list:**
+
+```bash
+acc-fwu --database --remove
+```
+
+Databases on engines other than `mysql` or `postgresql` are reported as a per-database skip. Failures on individual databases are logged and counted in the final summary but do not abort the run.
+
+### Cron Job Example
+
+To automatically update your firewall rules (along with LKE / LKE-E Control Plane ACLs and Managed Database `allow_list`s) every hour:
+
+```bash
+# Update firewall rules + LKE ACLs + database allow_lists every hour
 0 * * * * /usr/local/bin/acc-fwu --quiet
 
-# Firewall only (skip LKE step)
-0 * * * * /usr/local/bin/acc-fwu --quiet --no-lke
+# Firewall only (skip LKE and database steps)
+0 * * * * /usr/local/bin/acc-fwu --quiet --no-lke --no-database
 ```
 
 **Important**: Before using `--quiet` mode, you must have a valid configuration file (`~/.acc-fwu-config`) with your `firewall_id` and `label`. Interactive firewall selection is not available in quiet mode. Run `acc-fwu` interactively first to set up your configuration.

--- a/src/acc_fwu/cli.py
+++ b/src/acc_fwu/cli.py
@@ -12,6 +12,7 @@ from .firewall import (
     select_firewall,
 )
 from .lke import list_lke_clusters, update_all_lke_acls
+from .databases import list_databases, update_all_database_acls
 from .output import format_target
 
 # Version is set dynamically by setuptools_scm, fallback for development
@@ -90,6 +91,44 @@ def _handle_lke_command(args):
     )
 
 
+def _handle_database_list_command():
+    """Handle the --list command when combined with --database."""
+    databases = list_databases()
+    if not databases:
+        print("No managed databases found in your Linode account.")
+        return
+
+    rows = [
+        (
+            db["id"],
+            db["label"],
+            db["region"],
+            db.get("engine", ""),
+            db.get("version", ""),
+            db["status"],
+        )
+        for db in databases
+    ]
+    _print_table(
+        "Available managed databases:",
+        ["ID", "Label", "Region", "Engine", "Version", "Status"],
+        rows,
+    )
+
+
+def _handle_database_command(args):
+    """Handle managed database allow_list operations across all databases."""
+    if args.list:
+        _handle_database_list_command()
+        return
+    update_all_database_acls(
+        debug=args.debug,
+        quiet=args.quiet,
+        dry_run=args.dry_run,
+        remove=args.remove,
+    )
+
+
 def _resolve_config_from_file(args_label, quiet=False):
     """Load config from file, using args_label as fallback."""
     firewall_id, label = load_config()
@@ -146,14 +185,24 @@ def _create_parser():
     parser.add_argument("-a", "--add", action="store_true",
                         help="Add IP to existing rules instead of replacing (useful for multiple locations).")
     parser.add_argument("-l", "--list", action="store_true",
-                        help="List available firewalls (or LKE clusters with --lke) and exit.")
+                        help="List available firewalls (or LKE clusters with --lke, "
+                             "or managed databases with --database) and exit.")
     parser.add_argument("--lke", action="store_true",
                         help="Target LKE/LKE-E Control Plane ACLs only; skip firewall rules. "
                              "Adds (or removes with -r) your current public IP to every "
                              "cluster's ACL.")
     parser.add_argument("--no-lke", action="store_true",
                         help="Skip the default LKE/LKE-E Control Plane ACL update. "
-                             "By default, acc-fwu updates both firewall rules and LKE ACLs.")
+                             "By default, acc-fwu updates firewall rules, LKE ACLs, "
+                             "and managed database allow_lists.")
+    parser.add_argument("--database", action="store_true",
+                        help="Target managed database allow_lists only; skip firewall rules. "
+                             "Adds (or removes with -r) your current public IP to every "
+                             "managed database's allow_list.")
+    parser.add_argument("--no-database", action="store_true",
+                        help="Skip the default managed database allow_list update. "
+                             "By default, acc-fwu updates firewall rules, LKE ACLs, "
+                             "and managed database allow_lists.")
     parser.add_argument("-q", "--quiet", action="store_true",
                         help="Suppress output messages (useful for cron/scripting).")
     parser.add_argument("--dry-run", action="store_true",
@@ -182,6 +231,21 @@ def _execute_firewall_operation(args, firewall_id, label):
                              dry_run=args.dry_run, add_ip=args.add)
 
 
+def _run_implicit_batch_updates(args):
+    """Run the LKE and managed database batch updates that follow a firewall change."""
+    common = {
+        "debug": args.debug,
+        "quiet": args.quiet,
+        "dry_run": args.dry_run,
+        "remove": args.remove,
+        "implicit": True,
+    }
+    if not args.no_lke:
+        update_all_lke_acls(**common)
+    if not args.no_database:
+        update_all_database_acls(**common)
+
+
 def main():
     """
     Main CLI entry point for acc-fwu.
@@ -197,21 +261,17 @@ def main():
             _handle_lke_command(args)
             return
 
+        if args.database:
+            _handle_database_command(args)
+            return
+
         if args.list:
             _handle_list_command(args.debug)
             return
 
         firewall_id, label = _resolve_firewall_config(args)
         _execute_firewall_operation(args, firewall_id, label)
-
-        if not args.no_lke:
-            update_all_lke_acls(
-                debug=args.debug,
-                quiet=args.quiet,
-                dry_run=args.dry_run,
-                remove=args.remove,
-                implicit=True,
-            )
+        _run_implicit_batch_updates(args)
 
     except (ValueError, EOFError, KeyboardInterrupt) as e:
         if not args.quiet:

--- a/src/acc_fwu/cli.py
+++ b/src/acc_fwu/cli.py
@@ -188,17 +188,17 @@ def _create_parser():
                         help="List available firewalls (or LKE clusters with --lke, "
                              "or managed databases with --database) and exit.")
     parser.add_argument("--lke", action="store_true",
-                        help="Target LKE/LKE-E Control Plane ACLs only; skip firewall rules. "
+                        help="Target LKE/LKE-E Control Plane ACLs; skip firewall rules. "
                              "Adds (or removes with -r) your current public IP to every "
-                             "cluster's ACL.")
+                             "cluster's ACL. Combinable with --database.")
     parser.add_argument("--no-lke", action="store_true",
                         help="Skip the default LKE/LKE-E Control Plane ACL update. "
                              "By default, acc-fwu updates firewall rules, LKE ACLs, "
                              "and managed database allow_lists.")
     parser.add_argument("--database", action="store_true",
-                        help="Target managed database allow_lists only; skip firewall rules. "
+                        help="Target managed database allow_lists; skip firewall rules. "
                              "Adds (or removes with -r) your current public IP to every "
-                             "managed database's allow_list.")
+                             "managed database's allow_list. Combinable with --lke.")
     parser.add_argument("--no-database", action="store_true",
                         help="Skip the default managed database allow_list update. "
                              "By default, acc-fwu updates firewall rules, LKE ACLs, "
@@ -257,12 +257,14 @@ def main():
     args = parser.parse_args()
 
     try:
-        if args.lke:
-            _handle_lke_command(args)
-            return
-
-        if args.database:
-            _handle_database_command(args)
+        if args.lke or args.database:
+            # Explicit selectors: skip the firewall path and run whichever
+            # resource types were requested. Combining --lke and --database is
+            # supported and runs both in sequence.
+            if args.lke:
+                _handle_lke_command(args)
+            if args.database:
+                _handle_database_command(args)
             return
 
         if args.list:

--- a/src/acc_fwu/databases.py
+++ b/src/acc_fwu/databases.py
@@ -75,6 +75,13 @@ def list_databases():
             "status": db.get("status", "unknown"),
             "platform": db.get("platform", ""),
             "allow_list": list(db.get("allow_list") or []),
+            # VPC attachment surface. ``private_network`` is the authoritative
+            # signal per the Linode API: it is null when no VPC is configured,
+            # otherwise an object describing the VPC binding. We also retain
+            # ``vpc_id`` and ``public_access`` for diagnostics/messages.
+            "private_network": db.get("private_network"),
+            "vpc_id": db.get("vpc_id"),
+            "public_access": db.get("public_access"),
         }
         for db in databases
     ]
@@ -110,7 +117,7 @@ def put_database_allow_list(database_id, engine, allow_list, headers=None, debug
 
 def _format_database_label(database):
     """Return a human-readable identifier for logging."""
-    engine = database.get("engine", "") or "database"
+    engine = database.get("engine")
     type_name = f"{engine} database" if engine else "database"
     return format_target(type_name, database.get("label", ""), database["id"])
 
@@ -163,14 +170,39 @@ def _report_unchanged(db_label, ip_with_mask, remove, quiet):
     print(format_noop(ip_with_mask, db_label, remove=remove))
 
 
+def _check_skip_reason(database, db_label, quiet):
+    """Return a skip reason string if the database should be skipped, else None.
+
+    Per the Linode API, ``private_network`` is null when no VPC is configured
+    and an object describing the VPC binding otherwise. We deliberately skip
+    VPC-attached databases — even though allow_list is technically still
+    honoured when ``public_access`` is true, the public IP we detect from
+    ipify cannot reach a VPC-only endpoint, and updating these silently
+    would mislead the user about which databases are actually reachable.
+    """
+    engine = database.get("engine", "")
+    if engine not in SUPPORTED_DB_ENGINES:
+        return f"unsupported engine '{engine}'"
+
+    if database.get("private_network") is not None:
+        vpc_id = database.get("vpc_id")
+        return (
+            f"attached to VPC (vpc_id={vpc_id}); allow_list update skipped"
+            if vpc_id is not None
+            else "attached to VPC; allow_list update skipped"
+        )
+
+    return None
+
+
 def _process_database(database, ip_with_mask, remove, debug, quiet, dry_run, headers):
     """Apply the IP change to a single database's allow_list."""
     db_label = _format_database_label(database)
 
-    engine = database.get("engine", "")
-    if engine not in SUPPORTED_DB_ENGINES:
+    skip_reason = _check_skip_reason(database, db_label, quiet)
+    if skip_reason is not None:
         if not quiet:
-            print(format_skip(db_label, f"unsupported engine '{engine}'"))
+            print(format_skip(db_label, skip_reason))
         return "failed"
 
     allow_list = database.get("allow_list", [])

--- a/src/acc_fwu/databases.py
+++ b/src/acc_fwu/databases.py
@@ -1,0 +1,236 @@
+import requests
+
+from .firewall import (
+    CONTENT_TYPE_JSON,
+    LINODE_API_PAGE_SIZE,
+    REQUESTS_TIMEOUT,
+    get_api_token,
+    get_public_ip,
+)
+from .output import (
+    format_batch_preamble,
+    format_dry_run,
+    format_noop,
+    format_result,
+    format_skip,
+    format_summary,
+    format_target,
+)
+
+LINODE_DATABASES_BASE_URL = "https://api.linode.com/v4/databases"
+LINODE_DATABASES_LIST_URL = f"{LINODE_DATABASES_BASE_URL}/instances"
+
+# Engines whose allow_list this tool knows how to update. The PUT endpoint is
+# rooted at /databases/<engine>/instances/<id>, so any engine the API exposes
+# in the listing but not here will be reported as a skip.
+SUPPORTED_DB_ENGINES = ("mysql", "postgresql")
+
+
+def _auth_headers():
+    """Build authorization headers for Linode API requests."""
+    return {
+        "Authorization": f"Bearer {get_api_token()}",
+        "Content-Type": CONTENT_TYPE_JSON,
+    }
+
+
+def list_databases():
+    """
+    List all managed database instances from the Linode API.
+
+    The ``/databases/instances`` endpoint returns every Managed Database on the
+    account regardless of engine. The instance object already contains the
+    ``allow_list`` so callers do not need a second GET per database.
+
+    Returns:
+        list: Dicts with keys ``id``, ``label``, ``region``, ``engine``,
+        ``version``, ``status``, ``platform``, and ``allow_list``.
+    """
+    headers = _auth_headers()
+    databases = []
+    page = 1
+
+    while True:
+        response = requests.get(
+            LINODE_DATABASES_LIST_URL,
+            headers=headers,
+            params={"page": page, "page_size": LINODE_API_PAGE_SIZE},
+            timeout=REQUESTS_TIMEOUT,
+        )
+        response.raise_for_status()
+        data = response.json()
+        databases.extend(data.get("data", []))
+
+        if page >= data.get("pages", 1):
+            break
+        page += 1
+
+    return [
+        {
+            "id": db["id"],
+            "label": db.get("label", ""),
+            "region": db.get("region", ""),
+            "engine": db.get("engine", ""),
+            "version": db.get("version", ""),
+            "status": db.get("status", "unknown"),
+            "platform": db.get("platform", ""),
+            "allow_list": list(db.get("allow_list") or []),
+        }
+        for db in databases
+    ]
+
+
+def put_database_allow_list(database_id, engine, allow_list, headers=None, debug=False):
+    """
+    PUT an updated allow_list to a managed database instance.
+
+    Args:
+        database_id (int|str): The database instance ID.
+        engine (str): The database engine, used in the URL path
+            (``mysql`` or ``postgresql``).
+        allow_list (list): The replacement list of CIDR/IP strings.
+        headers (dict, optional): Reuse existing auth headers.
+        debug (bool): Print request/response details on failure.
+    """
+    if headers is None:
+        headers = _auth_headers()
+
+    response = requests.put(
+        f"{LINODE_DATABASES_BASE_URL}/{engine}/instances/{database_id}",
+        headers=headers,
+        json={"allow_list": allow_list},
+        timeout=REQUESTS_TIMEOUT,
+    )
+    if response.status_code != 200:
+        if debug:
+            print("Response status code:", response.status_code)
+            print("Response content:", response.content)
+        response.raise_for_status()
+
+
+def _format_database_label(database):
+    """Return a human-readable identifier for logging."""
+    engine = database.get("engine", "") or "database"
+    type_name = f"{engine} database" if engine else "database"
+    return format_target(type_name, database.get("label", ""), database["id"])
+
+
+def _apply_ip_to_allow_list(allow_list, ip_with_mask, remove):
+    """
+    Apply the IP change to an allow_list in a copy-safe manner.
+
+    Returns:
+        tuple: (new_allow_list, changed, already_in_state)
+          - new_allow_list: updated list (copy)
+          - changed: True if the list would change
+          - already_in_state: True if no change needed (IP already
+            present for add, or absent for remove)
+    """
+    new_list = list(allow_list or [])
+
+    if remove:
+        if ip_with_mask not in new_list:
+            return new_list, False, True
+        new_list = [ip for ip in new_list if ip != ip_with_mask]
+    else:
+        if ip_with_mask in new_list:
+            return new_list, False, True
+        new_list.append(ip_with_mask)
+
+    return new_list, True, False
+
+
+def _commit_allow_list_change(database, db_label, new_list, headers, debug, quiet):
+    """PUT the updated allow_list, returning True on success."""
+    try:
+        put_database_allow_list(
+            database["id"],
+            database["engine"],
+            new_list,
+            headers=headers,
+            debug=debug,
+        )
+        return True
+    except requests.RequestException as e:
+        if not quiet:
+            print(format_skip(db_label, f"failed to update ({e})"))
+        return False
+
+
+def _report_unchanged(db_label, ip_with_mask, remove, quiet):
+    if quiet:
+        return
+    print(format_noop(ip_with_mask, db_label, remove=remove))
+
+
+def _process_database(database, ip_with_mask, remove, debug, quiet, dry_run, headers):
+    """Apply the IP change to a single database's allow_list."""
+    db_label = _format_database_label(database)
+
+    engine = database.get("engine", "")
+    if engine not in SUPPORTED_DB_ENGINES:
+        if not quiet:
+            print(format_skip(db_label, f"unsupported engine '{engine}'"))
+        return "failed"
+
+    allow_list = database.get("allow_list", [])
+    if debug:
+        print(f"Current allow_list for {db_label}: {allow_list}")
+
+    new_list, changed, _ = _apply_ip_to_allow_list(allow_list, ip_with_mask, remove)
+    if not changed:
+        _report_unchanged(db_label, ip_with_mask, remove, quiet)
+        return "unchanged"
+
+    if dry_run:
+        if not quiet:
+            print(format_dry_run(ip_with_mask, db_label, remove=remove))
+        return "changed"
+
+    if not _commit_allow_list_change(database, db_label, new_list, headers, debug, quiet):
+        return "failed"
+
+    if not quiet:
+        print(format_result(ip_with_mask, db_label, remove=remove))
+    return "changed"
+
+
+def update_all_database_acls(debug=False, quiet=False, dry_run=False, remove=False, implicit=False):
+    """
+    Add (or remove) the current public IP on every managed database's allow_list.
+
+    Args:
+        debug (bool): Print verbose state and API error details.
+        quiet (bool): Suppress informational output.
+        dry_run (bool): Show the planned changes without calling the PUT API.
+        remove (bool): Remove the IP instead of adding it.
+        implicit (bool): True when this call is part of the default firewall+LKE
+            +database run (i.e., user did not pass ``--database`` explicitly).
+            Suppresses the "No managed databases found" notice so users without
+            any databases see no extra output.
+
+    Returns:
+        dict: Summary counts: ``changed``, ``unchanged``, ``failed``, ``total``.
+    """
+    headers = _auth_headers()
+    databases = list_databases()
+
+    if not databases:
+        if not quiet and not implicit:
+            print("No managed databases found in your Linode account.")
+        return {"changed": 0, "unchanged": 0, "failed": 0, "total": 0}
+
+    ip_with_mask = f"{get_public_ip()}/32"
+
+    if not quiet:
+        print(format_batch_preamble(ip_with_mask, "managed database(s)", len(databases), remove=remove))
+
+    counts = {"changed": 0, "unchanged": 0, "failed": 0, "total": len(databases)}
+    for database in databases:
+        result = _process_database(database, ip_with_mask, remove, debug, quiet, dry_run, headers)
+        counts[result] = counts.get(result, 0) + 1
+
+    if not quiet:
+        print(format_summary(counts))
+
+    return counts

--- a/src/acc_fwu/firewall.py
+++ b/src/acc_fwu/firewall.py
@@ -1,3 +1,4 @@
+import functools
 import os
 import re
 import stat
@@ -195,12 +196,14 @@ def get_api_token():
     return api_token
 
 
+@functools.lru_cache(maxsize=1)
 def get_public_ip():
     """
     Get the public IP address of the machine running this script.
 
-    This function makes an HTTP request to the 'api.ipify.org' service to
-    get the public IP address of the machine.
+    Cached for the lifetime of the process so a single ``acc-fwu`` invocation
+    only makes one request to ``api.ipify.org`` regardless of how many
+    deployment types (firewall, LKE, database) consume it.
 
     Returns:
         str: The public IP address of the machine.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+
+from acc_fwu.firewall import get_public_ip
+
+
+@pytest.fixture(autouse=True)
+def _clear_public_ip_cache():
+    """Clear the process-wide public-IP cache between tests so each test sees
+    its own mock for ``requests.get`` / ``get_public_ip``."""
+    get_public_ip.cache_clear()
+    yield
+    get_public_ip.cache_clear()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,7 +21,7 @@ class TestCliBasicOperations:
 
         monkeypatch.setattr(
             sys, 'argv',
-            ['acc-fwu', '--firewall_id', '12345', '--label', 'Test-Label', '--no-lke'],
+            ['acc-fwu', '--firewall_id', '12345', '--label', 'Test-Label', '--no-lke', '--no-database'],
         )
 
         main()
@@ -39,7 +39,7 @@ class TestCliBasicOperations:
         monkeypatch.setattr("acc_fwu.cli.load_config", mock_load_config)
         monkeypatch.setattr("acc_fwu.cli.update_firewall_rule", mock_update_firewall_rule)
 
-        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--no-lke'])
+        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--no-lke', '--no-database'])
 
         main()
 
@@ -53,7 +53,7 @@ class TestCliBasicOperations:
         mock_load_config = mock.MagicMock(side_effect=FileNotFoundError)
 
         monkeypatch.setattr("acc_fwu.cli.load_config", mock_load_config)
-        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--no-lke'])
+        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--no-lke', '--no-database'])
 
         with pytest.raises(SystemExit) as exc_info:
             main()
@@ -69,7 +69,7 @@ class TestCliBasicOperations:
         monkeypatch.setattr("acc_fwu.cli.load_config", mock_load_config)
         monkeypatch.setattr("acc_fwu.cli.update_firewall_rule", mock_update_firewall_rule)
 
-        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--no-lke'])
+        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--no-lke', '--no-database'])
 
         main()
 
@@ -86,7 +86,7 @@ class TestCliBasicOperations:
 
         monkeypatch.setattr("acc_fwu.cli.load_config", mock_load_config)
         monkeypatch.setattr("acc_fwu.cli.update_firewall_rule", mock_update_firewall_rule)
-        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--no-lke'])
+        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--no-lke', '--no-database'])
 
         main()
 
@@ -102,7 +102,7 @@ class TestCliBasicOperations:
 
         monkeypatch.setattr("acc_fwu.cli.load_config", mock_load_config)
         monkeypatch.setattr("acc_fwu.cli.update_firewall_rule", mock_update_firewall_rule)
-        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--no-lke', '-q'])
+        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--no-lke', '--no-database', '-q'])
 
         main()
 
@@ -127,7 +127,7 @@ class TestCliRemoveOperation:
 
         monkeypatch.setattr(
             sys, 'argv',
-            ['acc-fwu', '--firewall_id', '12345', '--label', 'Test-Label', '-r', '--no-lke'],
+            ['acc-fwu', '--firewall_id', '12345', '--label', 'Test-Label', '-r', '--no-lke', '--no-database'],
         )
 
         main()
@@ -155,7 +155,7 @@ class TestCliNewOptions:
 
         monkeypatch.setattr(
             sys, 'argv',
-            ['acc-fwu', '--firewall_id', '12345', '--label', 'Test-Label', '-q', '--no-lke'],
+            ['acc-fwu', '--firewall_id', '12345', '--label', 'Test-Label', '-q', '--no-lke', '--no-database'],
         )
 
         main()
@@ -179,7 +179,7 @@ class TestCliNewOptions:
 
         monkeypatch.setattr(
             sys, 'argv',
-            ['acc-fwu', '--firewall_id', '12345', '--label', 'Test-Label', '--dry-run', '--no-lke'],
+            ['acc-fwu', '--firewall_id', '12345', '--label', 'Test-Label', '--dry-run', '--no-lke', '--no-database'],
         )
 
         main()
@@ -202,7 +202,7 @@ class TestCliNewOptions:
         monkeypatch.setattr("acc_fwu.cli.validate_firewall_id", mock_validate_firewall_id)
         monkeypatch.setattr("acc_fwu.cli.validate_label", mock_validate_label)
 
-        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--firewall_id', '12345', '-d', '--no-lke'])
+        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--firewall_id', '12345', '-d', '--no-lke', '--no-database'])
 
         main()
 
@@ -215,7 +215,7 @@ class TestCliNewOptions:
         mock_load_config = mock.MagicMock(side_effect=FileNotFoundError)
 
         monkeypatch.setattr("acc_fwu.cli.load_config", mock_load_config)
-        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '-q', '--no-lke'])
+        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '-q', '--no-lke', '--no-database'])
 
         with pytest.raises(SystemExit) as exc_info:
             main()
@@ -262,7 +262,7 @@ class TestCliErrorHandling:
 
         monkeypatch.setattr("acc_fwu.cli.load_config", mock_load_config)
         monkeypatch.setattr("acc_fwu.cli.update_firewall_rule", mock_update_firewall_rule)
-        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--no-lke'])
+        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--no-lke', '--no-database'])
 
         with pytest.raises(SystemExit) as exc_info:
             main()
@@ -280,7 +280,7 @@ class TestCliErrorHandling:
 
         monkeypatch.setattr("acc_fwu.cli.load_config", mock_load_config)
         monkeypatch.setattr("acc_fwu.cli.update_firewall_rule", mock_update_firewall_rule)
-        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--no-lke'])
+        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--no-lke', '--no-database'])
 
         with pytest.raises(SystemExit) as exc_info:
             main()
@@ -299,7 +299,7 @@ class TestCliErrorHandling:
 
         monkeypatch.setattr("acc_fwu.cli.load_config", mock_load_config)
         monkeypatch.setattr("acc_fwu.cli.update_firewall_rule", mock_update_firewall_rule)
-        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--debug', '--no-lke'])
+        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--debug', '--no-lke', '--no-database'])
 
         # With --debug, the exception should be re-raised, not caught
         with pytest.raises(RuntimeError, match="Unexpected error"):
@@ -340,7 +340,7 @@ class TestCliAddFlag:
 
         monkeypatch.setattr(
             sys, 'argv',
-            ['acc-fwu', '--firewall_id', '12345', '--label', 'Test', '-a', '--no-lke'],
+            ['acc-fwu', '--firewall_id', '12345', '--label', 'Test', '-a', '--no-lke', '--no-database'],
         )
 
         main()
@@ -357,7 +357,7 @@ class TestCliAddFlag:
         monkeypatch.setattr("acc_fwu.cli.load_config", mock_load_config)
         monkeypatch.setattr("acc_fwu.cli.update_firewall_rule", mock_update_firewall_rule)
 
-        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--add', '--no-lke'])
+        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--add', '--no-lke', '--no-database'])
 
         main()
 
@@ -431,7 +431,7 @@ class TestCliInteractiveSelection:
         monkeypatch.setattr("acc_fwu.cli.save_config", mock_save_config)
         monkeypatch.setattr("acc_fwu.cli.update_firewall_rule", mock_update_firewall_rule)
 
-        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--no-lke'])
+        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--no-lke', '--no-database'])
 
         main()
 
@@ -453,7 +453,7 @@ class TestCliInteractiveSelection:
         monkeypatch.setattr("acc_fwu.cli.save_config", mock_save_config)
         monkeypatch.setattr("acc_fwu.cli.update_firewall_rule", mock_update_firewall_rule)
 
-        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--dry-run', '--no-lke'])
+        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--dry-run', '--no-lke', '--no-database'])
 
         main()
 
@@ -471,7 +471,7 @@ class TestCliInteractiveSelection:
         monkeypatch.setattr("acc_fwu.cli.load_config", mock_load_config)
         monkeypatch.setattr("acc_fwu.cli.select_firewall", mock_select_firewall)
 
-        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--no-lke'])
+        monkeypatch.setattr(sys, 'argv', ['acc-fwu', '--no-lke', '--no-database'])
 
         with pytest.raises(SystemExit) as exc_info:
             main()
@@ -586,11 +586,13 @@ class TestCliDefaultLkeBehavior:
         mock_load = mock.MagicMock(return_value=("12345", "Label"))
         mock_update_fw = mock.MagicMock()
         mock_update_lke = mock.MagicMock()
+        mock_update_db = mock.MagicMock()
 
         monkeypatch.setattr("acc_fwu.cli.load_config", mock_load)
         monkeypatch.setattr("acc_fwu.cli.update_firewall_rule", mock_update_fw)
         monkeypatch.setattr("acc_fwu.cli.update_all_lke_acls", mock_update_lke)
-        monkeypatch.setattr(sys, "argv", ["acc-fwu"])
+        monkeypatch.setattr("acc_fwu.cli.update_all_database_acls", mock_update_db)
+        monkeypatch.setattr(sys, "argv", ["acc-fwu", "--no-database"])
 
         main()
 
@@ -604,11 +606,13 @@ class TestCliDefaultLkeBehavior:
         mock_load = mock.MagicMock(return_value=("12345", "Label"))
         mock_update_fw = mock.MagicMock()
         mock_update_lke = mock.MagicMock()
+        mock_update_db = mock.MagicMock()
 
         monkeypatch.setattr("acc_fwu.cli.load_config", mock_load)
         monkeypatch.setattr("acc_fwu.cli.update_firewall_rule", mock_update_fw)
         monkeypatch.setattr("acc_fwu.cli.update_all_lke_acls", mock_update_lke)
-        monkeypatch.setattr(sys, "argv", ["acc-fwu", "--no-lke"])
+        monkeypatch.setattr("acc_fwu.cli.update_all_database_acls", mock_update_db)
+        monkeypatch.setattr(sys, "argv", ["acc-fwu", "--no-lke", "--no-database"])
 
         main()
 
@@ -620,11 +624,13 @@ class TestCliDefaultLkeBehavior:
         mock_load = mock.MagicMock(return_value=("12345", "Label"))
         mock_remove_fw = mock.MagicMock()
         mock_update_lke = mock.MagicMock()
+        mock_update_db = mock.MagicMock()
 
         monkeypatch.setattr("acc_fwu.cli.load_config", mock_load)
         monkeypatch.setattr("acc_fwu.cli.remove_firewall_rule", mock_remove_fw)
         monkeypatch.setattr("acc_fwu.cli.update_all_lke_acls", mock_update_lke)
-        monkeypatch.setattr(sys, "argv", ["acc-fwu", "-r"])
+        monkeypatch.setattr("acc_fwu.cli.update_all_database_acls", mock_update_db)
+        monkeypatch.setattr(sys, "argv", ["acc-fwu", "-r", "--no-database"])
 
         main()
 
@@ -632,6 +638,157 @@ class TestCliDefaultLkeBehavior:
         mock_update_lke.assert_called_once_with(
             debug=False, quiet=False, dry_run=False, remove=True, implicit=True,
         )
+
+
+class TestCliDefaultDatabaseBehavior:
+    """Tests for the default-on managed database update that runs alongside firewall updates."""
+
+    def test_firewall_run_also_updates_databases_by_default(self, monkeypatch):
+        """Without --database/--no-database, a firewall update also calls update_all_database_acls."""
+        mock_load = mock.MagicMock(return_value=("12345", "Label"))
+        mock_update_fw = mock.MagicMock()
+        mock_update_lke = mock.MagicMock()
+        mock_update_db = mock.MagicMock()
+
+        monkeypatch.setattr("acc_fwu.cli.load_config", mock_load)
+        monkeypatch.setattr("acc_fwu.cli.update_firewall_rule", mock_update_fw)
+        monkeypatch.setattr("acc_fwu.cli.update_all_lke_acls", mock_update_lke)
+        monkeypatch.setattr("acc_fwu.cli.update_all_database_acls", mock_update_db)
+        monkeypatch.setattr(sys, "argv", ["acc-fwu", "--no-lke"])
+
+        main()
+
+        mock_update_fw.assert_called_once()
+        mock_update_db.assert_called_once_with(
+            debug=False, quiet=False, dry_run=False, remove=False, implicit=True,
+        )
+
+    def test_no_database_flag_skips_database_update(self, monkeypatch):
+        """--no-database should skip the implicit managed database allow_list update."""
+        mock_load = mock.MagicMock(return_value=("12345", "Label"))
+        mock_update_fw = mock.MagicMock()
+        mock_update_lke = mock.MagicMock()
+        mock_update_db = mock.MagicMock()
+
+        monkeypatch.setattr("acc_fwu.cli.load_config", mock_load)
+        monkeypatch.setattr("acc_fwu.cli.update_firewall_rule", mock_update_fw)
+        monkeypatch.setattr("acc_fwu.cli.update_all_lke_acls", mock_update_lke)
+        monkeypatch.setattr("acc_fwu.cli.update_all_database_acls", mock_update_db)
+        monkeypatch.setattr(sys, "argv", ["acc-fwu", "--no-lke", "--no-database"])
+
+        main()
+
+        mock_update_fw.assert_called_once()
+        mock_update_db.assert_not_called()
+
+    def test_remove_flag_propagates_to_implicit_database_update(self, monkeypatch):
+        """acc-fwu -r should remove IP from managed databases by default."""
+        mock_load = mock.MagicMock(return_value=("12345", "Label"))
+        mock_remove_fw = mock.MagicMock()
+        mock_update_lke = mock.MagicMock()
+        mock_update_db = mock.MagicMock()
+
+        monkeypatch.setattr("acc_fwu.cli.load_config", mock_load)
+        monkeypatch.setattr("acc_fwu.cli.remove_firewall_rule", mock_remove_fw)
+        monkeypatch.setattr("acc_fwu.cli.update_all_lke_acls", mock_update_lke)
+        monkeypatch.setattr("acc_fwu.cli.update_all_database_acls", mock_update_db)
+        monkeypatch.setattr(sys, "argv", ["acc-fwu", "-r", "--no-lke"])
+
+        main()
+
+        mock_remove_fw.assert_called_once()
+        mock_update_db.assert_called_once_with(
+            debug=False, quiet=False, dry_run=False, remove=True, implicit=True,
+        )
+
+
+class TestCliDatabaseFlag:
+    """Tests for the --database flag (managed database allow_list automation)."""
+
+    def test_database_flag_dispatches_to_update_all_database_acls(self, monkeypatch):
+        """Test --database dispatches to update_all_database_acls and skips firewall ops."""
+        mock_update = mock.MagicMock()
+        mock_update_fw = mock.MagicMock()
+
+        monkeypatch.setattr("acc_fwu.cli.update_all_database_acls", mock_update)
+        monkeypatch.setattr("acc_fwu.cli.update_firewall_rule", mock_update_fw)
+        monkeypatch.setattr(sys, "argv", ["acc-fwu", "--database"])
+
+        main()
+
+        mock_update.assert_called_once_with(
+            debug=False, quiet=False, dry_run=False, remove=False,
+        )
+        mock_update_fw.assert_not_called()
+
+    def test_database_with_remove_flag(self, monkeypatch):
+        """Test --database -r passes remove=True."""
+        mock_update = mock.MagicMock()
+        monkeypatch.setattr("acc_fwu.cli.update_all_database_acls", mock_update)
+        monkeypatch.setattr(sys, "argv", ["acc-fwu", "--database", "-r"])
+
+        main()
+
+        mock_update.assert_called_once_with(
+            debug=False, quiet=False, dry_run=False, remove=True,
+        )
+
+    def test_database_dry_run_quiet(self, monkeypatch):
+        """Test --database honors --dry-run and --quiet."""
+        mock_update = mock.MagicMock()
+        monkeypatch.setattr("acc_fwu.cli.update_all_database_acls", mock_update)
+        monkeypatch.setattr(sys, "argv", ["acc-fwu", "--database", "--dry-run", "-q"])
+
+        main()
+
+        mock_update.assert_called_once_with(
+            debug=False, quiet=True, dry_run=True, remove=False,
+        )
+
+    def test_database_list_shows_databases_and_exits(self, monkeypatch, capsys):
+        """Test --database --list shows managed databases and exits without touching allow_lists."""
+        mock_list = mock.MagicMock(return_value=[
+            {"id": 11, "label": "primary", "region": "us-east", "engine": "mysql",
+             "version": "8.0.30", "status": "active"},
+            {"id": 12, "label": "analytics", "region": "eu-west", "engine": "postgresql",
+             "version": "15", "status": "active"},
+        ])
+        mock_update = mock.MagicMock()
+        monkeypatch.setattr("acc_fwu.cli.list_databases", mock_list)
+        monkeypatch.setattr("acc_fwu.cli.update_all_database_acls", mock_update)
+        monkeypatch.setattr(sys, "argv", ["acc-fwu", "--database", "--list"])
+
+        main()
+
+        mock_update.assert_not_called()
+        captured = capsys.readouterr()
+        assert "primary" in captured.out
+        assert "analytics" in captured.out
+        assert "mysql" in captured.out
+        assert "postgresql" in captured.out
+
+    def test_database_list_no_databases(self, monkeypatch, capsys):
+        """Test --database --list when no databases exist."""
+        mock_list = mock.MagicMock(return_value=[])
+        monkeypatch.setattr("acc_fwu.cli.list_databases", mock_list)
+        monkeypatch.setattr(sys, "argv", ["acc-fwu", "--database", "--list"])
+
+        main()
+
+        captured = capsys.readouterr()
+        assert "No managed databases found" in captured.out
+
+    def test_database_skips_firewall_resolution(self, monkeypatch):
+        """Test that --database skips firewall config resolution entirely."""
+        mock_update = mock.MagicMock()
+        mock_load_config = mock.MagicMock(side_effect=AssertionError("must not be called"))
+        monkeypatch.setattr("acc_fwu.cli.update_all_database_acls", mock_update)
+        monkeypatch.setattr("acc_fwu.cli.load_config", mock_load_config)
+        monkeypatch.setattr(sys, "argv", ["acc-fwu", "--database"])
+
+        main()
+
+        mock_update.assert_called_once()
 
 
 class TestCliListTableFormatting:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -578,6 +578,43 @@ class TestCliLkeFlag:
         mock_load.assert_not_called()
 
 
+class TestCliCombinedSelectors:
+    """Tests for combining --lke and --database selectors in the same run."""
+
+    def test_lke_and_database_run_both_skip_firewall(self, monkeypatch):
+        """--lke --database should run both batch updates and skip the firewall path."""
+        mock_lke = mock.MagicMock()
+        mock_db = mock.MagicMock()
+        mock_update_fw = mock.MagicMock()
+        mock_load = mock.MagicMock()
+
+        monkeypatch.setattr("acc_fwu.cli.update_all_lke_acls", mock_lke)
+        monkeypatch.setattr("acc_fwu.cli.update_all_database_acls", mock_db)
+        monkeypatch.setattr("acc_fwu.cli.update_firewall_rule", mock_update_fw)
+        monkeypatch.setattr("acc_fwu.cli.load_config", mock_load)
+        monkeypatch.setattr(sys, "argv", ["acc-fwu", "--lke", "--database"])
+
+        main()
+
+        mock_lke.assert_called_once()
+        mock_db.assert_called_once()
+        mock_update_fw.assert_not_called()
+        mock_load.assert_not_called()
+
+    def test_lke_and_database_with_remove(self, monkeypatch):
+        """-r propagates to both selectors when combined."""
+        mock_lke = mock.MagicMock()
+        mock_db = mock.MagicMock()
+        monkeypatch.setattr("acc_fwu.cli.update_all_lke_acls", mock_lke)
+        monkeypatch.setattr("acc_fwu.cli.update_all_database_acls", mock_db)
+        monkeypatch.setattr(sys, "argv", ["acc-fwu", "--lke", "--database", "-r"])
+
+        main()
+
+        assert mock_lke.call_args[1]["remove"] is True
+        assert mock_db.call_args[1]["remove"] is True
+
+
 class TestCliDefaultLkeBehavior:
     """Tests for the default-on LKE update that runs alongside firewall updates."""
 

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -270,6 +270,60 @@ class TestUpdateAllDatabaseAcls:
         captured = capsys.readouterr()
         assert captured.out == ""
 
+    def test_vpc_attached_database_is_skipped(self, monkeypatch, capsys):
+        """Databases with a non-null private_network are skipped (regardless of engine)."""
+        databases = [
+            {"id": 1, "label": "vpc-mysql", "engine": "mysql",
+             "allow_list": [], "private_network": {"vpc_id": 42, "subnet_id": 7},
+             "vpc_id": 42, "public_access": False},
+            {"id": 2, "label": "vpc-pg", "engine": "postgresql",
+             "allow_list": [], "private_network": {"vpc_id": 99, "subnet_id": 3},
+             "vpc_id": 99, "public_access": True},
+            {"id": 3, "label": "public-mysql", "engine": "mysql",
+             "allow_list": [], "private_network": None},
+        ]
+        put_mock = self._setup_common(monkeypatch, databases)
+
+        counts = update_all_database_acls(quiet=False)
+
+        assert counts["changed"] == 1
+        assert counts["failed"] == 2
+        # Only the non-VPC database is updated
+        put_mock.assert_called_once()
+        assert put_mock.call_args[0][0] == 3
+        captured = capsys.readouterr()
+        assert "attached to VPC" in captured.out
+        assert "vpc_id=42" in captured.out
+        assert "vpc_id=99" in captured.out
+
+    def test_vpc_skip_respects_quiet(self, monkeypatch, capsys):
+        databases = [
+            {"id": 1, "label": "vpc-db", "engine": "mysql",
+             "allow_list": [], "private_network": {"vpc_id": 1}},
+        ]
+        put_mock = self._setup_common(monkeypatch, databases)
+
+        counts = update_all_database_acls(quiet=True)
+
+        assert counts["failed"] == 1
+        put_mock.assert_not_called()
+        captured = capsys.readouterr()
+        assert captured.out == ""
+
+    def test_missing_private_network_field_treated_as_non_vpc(self, monkeypatch):
+        """Older API responses without the private_network field should not be
+        misclassified as VPC-attached."""
+        databases = [
+            {"id": 1, "label": "primary", "engine": "mysql", "allow_list": []},
+        ]
+        put_mock = self._setup_common(monkeypatch, databases)
+
+        counts = update_all_database_acls(quiet=True)
+
+        assert counts["changed"] == 1
+        assert counts["failed"] == 0
+        put_mock.assert_called_once()
+
     def test_unsupported_engine_is_failed(self, monkeypatch, capsys):
         databases = [
             {"id": 1, "label": "redis", "engine": "redis", "allow_list": []},

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -1,0 +1,337 @@
+import pytest
+import requests
+from unittest import mock
+
+from acc_fwu.databases import (
+    LINODE_DATABASES_BASE_URL,
+    LINODE_DATABASES_LIST_URL,
+    _apply_ip_to_allow_list,
+    list_databases,
+    put_database_allow_list,
+    update_all_database_acls,
+)
+from acc_fwu.firewall import LINODE_API_PAGE_SIZE
+
+
+HEADERS = {"Authorization": "Bearer test-token", "Content-Type": "application/json"}
+
+
+def _mock_response(json_data=None, status_code=200, raise_exc=None):
+    resp = mock.Mock()
+    resp.json.return_value = json_data if json_data is not None else {}
+    resp.status_code = status_code
+    resp.content = b""
+    if raise_exc is not None:
+        resp.raise_for_status = mock.Mock(side_effect=raise_exc)
+    else:
+        resp.raise_for_status = mock.Mock()
+    return resp
+
+
+class TestListDatabases:
+    def test_returns_databases_with_engine_and_allow_list(self, monkeypatch):
+        resp = _mock_response({
+            "data": [
+                {"id": 1, "label": "primary", "region": "us-east",
+                 "engine": "mysql", "version": "8.0.30", "status": "active",
+                 "platform": "rdbms-default",
+                 "allow_list": ["1.2.3.4/32"]},
+                {"id": 2, "label": "analytics", "region": "eu-west",
+                 "engine": "postgresql", "version": "15", "status": "active",
+                 "allow_list": []},
+            ],
+            "pages": 1,
+        })
+        monkeypatch.setattr(requests, "get", mock.Mock(return_value=resp))
+        monkeypatch.setattr("acc_fwu.databases.get_api_token", mock.Mock(return_value="test-token"))
+
+        databases = list_databases()
+        assert len(databases) == 2
+        assert databases[0]["engine"] == "mysql"
+        assert databases[0]["allow_list"] == ["1.2.3.4/32"]
+        assert databases[1]["engine"] == "postgresql"
+        assert databases[1]["allow_list"] == []
+
+    def test_pagination(self, monkeypatch):
+        page1 = _mock_response({
+            "data": [{"id": 1, "label": "a", "region": "us", "engine": "mysql"}],
+            "pages": 2,
+        })
+        page2 = _mock_response({
+            "data": [{"id": 2, "label": "b", "region": "us", "engine": "postgresql"}],
+            "pages": 2,
+        })
+        mock_get = mock.Mock(side_effect=[page1, page2])
+        monkeypatch.setattr(requests, "get", mock_get)
+        monkeypatch.setattr("acc_fwu.databases.get_api_token", mock.Mock(return_value="test-token"))
+
+        databases = list_databases()
+        assert [d["id"] for d in databases] == [1, 2]
+        assert mock_get.call_args_list[0][1]["params"] == {"page": 1, "page_size": LINODE_API_PAGE_SIZE}
+        assert mock_get.call_args_list[1][1]["params"] == {"page": 2, "page_size": LINODE_API_PAGE_SIZE}
+
+    def test_uses_correct_url(self, monkeypatch):
+        resp = _mock_response({"data": [], "pages": 1})
+        mock_get = mock.Mock(return_value=resp)
+        monkeypatch.setattr(requests, "get", mock_get)
+        monkeypatch.setattr("acc_fwu.databases.get_api_token", mock.Mock(return_value="test-token"))
+
+        list_databases()
+        assert mock_get.call_args[0][0] == LINODE_DATABASES_LIST_URL
+
+    def test_handles_missing_allow_list(self, monkeypatch):
+        resp = _mock_response({"data": [{"id": 1, "engine": "mysql"}], "pages": 1})
+        monkeypatch.setattr(requests, "get", mock.Mock(return_value=resp))
+        monkeypatch.setattr("acc_fwu.databases.get_api_token", mock.Mock(return_value="test-token"))
+
+        databases = list_databases()
+        assert databases[0]["allow_list"] == []
+        assert databases[0]["label"] == ""
+
+
+class TestPutDatabaseAllowList:
+    def test_sends_allow_list_to_engine_specific_url(self, monkeypatch):
+        resp = _mock_response(status_code=200)
+        mock_put = mock.Mock(return_value=resp)
+        monkeypatch.setattr(requests, "put", mock_put)
+
+        put_database_allow_list(42, "mysql", ["9.9.9.9/32"], headers=HEADERS)
+
+        assert mock_put.call_count == 1
+        assert mock_put.call_args[0][0] == f"{LINODE_DATABASES_BASE_URL}/mysql/instances/42"
+        assert mock_put.call_args[1]["json"] == {"allow_list": ["9.9.9.9/32"]}
+
+    def test_postgresql_engine_in_url(self, monkeypatch):
+        resp = _mock_response(status_code=200)
+        mock_put = mock.Mock(return_value=resp)
+        monkeypatch.setattr(requests, "put", mock_put)
+
+        put_database_allow_list(7, "postgresql", [], headers=HEADERS)
+
+        assert mock_put.call_args[0][0] == f"{LINODE_DATABASES_BASE_URL}/postgresql/instances/7"
+
+    def test_raises_on_error_status(self, monkeypatch):
+        resp = _mock_response(
+            status_code=400,
+            raise_exc=requests.exceptions.HTTPError("400"),
+        )
+        resp.content = b'{"errors": [{"reason": "bad"}]}'
+        monkeypatch.setattr(requests, "put", mock.Mock(return_value=resp))
+
+        with pytest.raises(requests.exceptions.HTTPError):
+            put_database_allow_list(42, "mysql", [], headers=HEADERS, debug=True)
+
+
+class TestApplyIpToAllowList:
+    def test_add_when_absent_adds(self):
+        new_list, changed, already = _apply_ip_to_allow_list(
+            ["1.1.1.1/32"], "2.2.2.2/32", remove=False,
+        )
+        assert changed is True
+        assert already is False
+        assert "2.2.2.2/32" in new_list
+        assert "1.1.1.1/32" in new_list
+
+    def test_add_when_present_noop(self):
+        _, changed, already = _apply_ip_to_allow_list(
+            ["2.2.2.2/32"], "2.2.2.2/32", remove=False,
+        )
+        assert changed is False
+        assert already is True
+
+    def test_remove_when_present_removes(self):
+        new_list, changed, already = _apply_ip_to_allow_list(
+            ["2.2.2.2/32", "1.1.1.1/32"], "2.2.2.2/32", remove=True,
+        )
+        assert changed is True
+        assert already is False
+        assert "2.2.2.2/32" not in new_list
+        assert new_list == ["1.1.1.1/32"]
+
+    def test_remove_when_absent_noop(self):
+        _, changed, already = _apply_ip_to_allow_list(
+            ["1.1.1.1/32"], "2.2.2.2/32", remove=True,
+        )
+        assert changed is False
+        assert already is True
+
+    def test_handles_none_allow_list(self):
+        new_list, changed, _ = _apply_ip_to_allow_list(None, "2.2.2.2/32", remove=False)
+        assert changed is True
+        assert new_list == ["2.2.2.2/32"]
+
+    def test_does_not_mutate_input(self):
+        original = ["1.1.1.1/32"]
+        new_list, _, _ = _apply_ip_to_allow_list(original, "2.2.2.2/32", remove=False)
+        assert original == ["1.1.1.1/32"]
+        assert new_list != original
+
+
+class TestUpdateAllDatabaseAcls:
+    def _setup_common(self, monkeypatch, databases, ip="9.9.9.9"):
+        """Configure common mocks for update_all_database_acls tests."""
+        monkeypatch.setattr("acc_fwu.databases.get_api_token", mock.Mock(return_value="test-token"))
+        monkeypatch.setattr("acc_fwu.databases.get_public_ip", mock.Mock(return_value=ip))
+        monkeypatch.setattr("acc_fwu.databases.list_databases", mock.Mock(return_value=databases))
+
+        put_mock = mock.Mock()
+        monkeypatch.setattr("acc_fwu.databases.put_database_allow_list", put_mock)
+        return put_mock
+
+    def test_adds_ip_to_all_databases(self, monkeypatch, capsys):
+        databases = [
+            {"id": 1, "label": "primary", "engine": "mysql", "allow_list": []},
+            {"id": 2, "label": "analytics", "engine": "postgresql",
+             "allow_list": ["1.1.1.1/32"]},
+        ]
+        put_mock = self._setup_common(monkeypatch, databases)
+
+        counts = update_all_database_acls(quiet=True)
+
+        assert counts == {"changed": 2, "unchanged": 0, "failed": 0, "total": 2}
+        assert put_mock.call_count == 2
+        # First call: db id=1 mysql, allow_list should now contain the IP
+        assert put_mock.call_args_list[0][0][0] == 1
+        assert put_mock.call_args_list[0][0][1] == "mysql"
+        assert "9.9.9.9/32" in put_mock.call_args_list[0][0][2]
+        # Second call: db id=2 postgresql with both IPs
+        assert put_mock.call_args_list[1][0][0] == 2
+        assert put_mock.call_args_list[1][0][1] == "postgresql"
+        assert "9.9.9.9/32" in put_mock.call_args_list[1][0][2]
+        assert "1.1.1.1/32" in put_mock.call_args_list[1][0][2]
+
+    def test_no_databases(self, monkeypatch, capsys):
+        monkeypatch.setattr("acc_fwu.databases.get_api_token", mock.Mock(return_value="test-token"))
+        monkeypatch.setattr("acc_fwu.databases.list_databases", mock.Mock(return_value=[]))
+        monkeypatch.setattr("acc_fwu.databases.get_public_ip", mock.Mock(return_value="9.9.9.9"))
+
+        counts = update_all_database_acls(quiet=False)
+
+        assert counts["total"] == 0
+        captured = capsys.readouterr()
+        assert "No managed databases found" in captured.out
+
+    def test_no_databases_implicit_is_silent(self, monkeypatch, capsys):
+        monkeypatch.setattr("acc_fwu.databases.get_api_token", mock.Mock(return_value="test-token"))
+        monkeypatch.setattr("acc_fwu.databases.list_databases", mock.Mock(return_value=[]))
+        monkeypatch.setattr("acc_fwu.databases.get_public_ip", mock.Mock(return_value="9.9.9.9"))
+
+        update_all_database_acls(quiet=False, implicit=True)
+
+        captured = capsys.readouterr()
+        assert captured.out == ""
+
+    def test_ip_already_present_is_unchanged(self, monkeypatch, capsys):
+        databases = [{"id": 1, "label": "primary", "engine": "mysql",
+                      "allow_list": ["9.9.9.9/32"]}]
+        put_mock = self._setup_common(monkeypatch, databases)
+
+        counts = update_all_database_acls(quiet=False)
+
+        assert counts["unchanged"] == 1
+        assert counts["changed"] == 0
+        put_mock.assert_not_called()
+        captured = capsys.readouterr()
+        assert "already present" in captured.out
+
+    def test_remove_mode(self, monkeypatch):
+        databases = [{"id": 1, "label": "primary", "engine": "mysql",
+                      "allow_list": ["9.9.9.9/32", "1.1.1.1/32"]}]
+        put_mock = self._setup_common(monkeypatch, databases)
+
+        counts = update_all_database_acls(quiet=True, remove=True)
+
+        assert counts["changed"] == 1
+        sent = put_mock.call_args[0][2]
+        assert sent == ["1.1.1.1/32"]
+
+    def test_dry_run_does_not_call_put(self, monkeypatch, capsys):
+        databases = [{"id": 1, "label": "primary", "engine": "mysql",
+                      "allow_list": []}]
+        put_mock = self._setup_common(monkeypatch, databases)
+
+        counts = update_all_database_acls(dry_run=True)
+
+        put_mock.assert_not_called()
+        assert counts["changed"] == 1
+        captured = capsys.readouterr()
+        assert "[DRY RUN]" in captured.out
+
+    def test_dry_run_respects_quiet(self, monkeypatch, capsys):
+        """--dry-run with quiet=True should produce no output."""
+        databases = [{"id": 1, "label": "primary", "engine": "mysql",
+                      "allow_list": []}]
+        put_mock = self._setup_common(monkeypatch, databases)
+
+        counts = update_all_database_acls(dry_run=True, quiet=True)
+
+        put_mock.assert_not_called()
+        assert counts["changed"] == 1
+        captured = capsys.readouterr()
+        assert captured.out == ""
+
+    def test_unsupported_engine_is_failed(self, monkeypatch, capsys):
+        databases = [
+            {"id": 1, "label": "redis", "engine": "redis", "allow_list": []},
+            {"id": 2, "label": "primary", "engine": "mysql", "allow_list": []},
+        ]
+        put_mock = self._setup_common(monkeypatch, databases)
+
+        counts = update_all_database_acls(quiet=False)
+
+        assert counts["failed"] == 1
+        assert counts["changed"] == 1
+        # Only the supported engine is updated
+        put_mock.assert_called_once()
+        assert put_mock.call_args[0][1] == "mysql"
+        captured = capsys.readouterr()
+        assert "unsupported engine" in captured.out
+
+    def test_put_failure_is_counted(self, monkeypatch, capsys):
+        databases = [{"id": 1, "label": "primary", "engine": "mysql",
+                      "allow_list": []}]
+        monkeypatch.setattr("acc_fwu.databases.get_api_token", mock.Mock(return_value="test-token"))
+        monkeypatch.setattr("acc_fwu.databases.list_databases", mock.Mock(return_value=databases))
+        monkeypatch.setattr("acc_fwu.databases.get_public_ip", mock.Mock(return_value="9.9.9.9"))
+        monkeypatch.setattr(
+            "acc_fwu.databases.put_database_allow_list",
+            mock.Mock(side_effect=requests.exceptions.HTTPError("500")),
+        )
+
+        counts = update_all_database_acls(quiet=False)
+
+        assert counts["failed"] == 1
+        assert counts["changed"] == 0
+        captured = capsys.readouterr()
+        assert "failed to update" in captured.out
+
+    def test_summary_printed_when_not_quiet(self, monkeypatch, capsys):
+        databases = [{"id": 1, "label": "primary", "engine": "mysql",
+                      "allow_list": []}]
+        self._setup_common(monkeypatch, databases)
+
+        update_all_database_acls(quiet=False)
+
+        captured = capsys.readouterr()
+        assert "Done." in captured.out
+        assert "changed=1" in captured.out
+
+    def test_per_database_failure_does_not_abort_batch(self, monkeypatch, capsys):
+        databases = [
+            {"id": 1, "label": "primary", "engine": "mysql", "allow_list": []},
+            {"id": 2, "label": "analytics", "engine": "postgresql", "allow_list": []},
+        ]
+        monkeypatch.setattr("acc_fwu.databases.get_api_token", mock.Mock(return_value="test-token"))
+        monkeypatch.setattr("acc_fwu.databases.list_databases", mock.Mock(return_value=databases))
+        monkeypatch.setattr("acc_fwu.databases.get_public_ip", mock.Mock(return_value="9.9.9.9"))
+
+        def fake_put(database_id, engine, allow_list, headers=None, debug=False):
+            if database_id == 1:
+                raise requests.exceptions.HTTPError("500")
+
+        monkeypatch.setattr("acc_fwu.databases.put_database_allow_list", fake_put)
+
+        counts = update_all_database_acls(quiet=True)
+        assert counts["changed"] == 1
+        assert counts["failed"] == 1
+        assert counts["total"] == 2


### PR DESCRIPTION
## Summary

- Adds a third deployment type — Linode **Managed Databases** (MySQL / PostgreSQL) — to the existing firewall + LKE batch run, syncing the user's public IP into each database's `allow_list` on every invocation.
- New `databases.py` module mirrors the shape of `lke.py`: paginated listing, idempotent add/remove, per-target failure isolation, and the shared `output.py` formatters so the lifecycle lines look identical to firewall and LKE output.
- New CLI flags: `--database` (databases-only mode, skip firewall + LKE) and `--no-database` (skip the implicit database step, matches the existing `--no-lke` pattern).

## Behavior

- **Default:** firewall update → LKE ACL sync → Managed Database `allow_list` sync. Accounts with no databases see no extra output (implicit-mode silence, matching LKE).
- **PUT endpoint is engine-rooted** (`/databases/{engine}/instances/{id}`), so the module only commits changes for `mysql` / `postgresql`. Other engines surfaced by `/databases/instances` are reported as a per-database skip rather than failing the whole batch.
- **`-r` / `--remove`** propagates through the implicit batch the same way it does for LKE.
- **`--list` with `--database`** prints a dynamic-width table of databases (id, label, region, engine, version, status) and exits without touching any allow_lists.

## Refactor

`main()` was approaching the flake8 complexity ceiling, so the implicit firewall+LKE+database tail is now a single helper `_run_implicit_batch_updates(args)`.

## Test plan

- [x] `python3 -m pytest` — 167 tests pass (24 new in `tests/test_databases.py`, 6 new CLI tests covering `--database`, `--no-database`, default-on behavior, `-r` propagation, and `--database --list`).
- [x] `flake8 . --select=E9,F63,F7,F82` — clean.
- [x] `flake8 . --max-complexity=10 --max-line-length=127` — clean (after `_run_implicit_batch_updates` extraction).
- [x] Existing CLI tests updated to pair `--no-database` with `--no-lke` so they stay isolated to firewall behavior.
- [ ] Manual smoke test against a live Linode account with at least one MySQL database (cannot run from CI environment).

## Docs

- `CLAUDE.md`: features list, codebase structure, CLI helper map, test catalog, API endpoints, and a new `Databases Module` section.
- `README.md`: features list, default-behavior numbered list, CLI usage block, and a new `Managed Database allow_list` section with examples plus an updated cron example.

https://claude.ai/code/session_01DKACp1Q6mKhfEaALknphYm

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKACp1Q6mKhfEaALknphYm)_