### PR TITLE
ci: bump GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -29,7 +29,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,7 +57,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`
@@ -67,7 +67,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -95,6 +95,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -28,9 +28,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@v5
         # Commonly enabled options, see https://github.com/actions/dependency-review-action#configuration-options for all available options.
         with:
           comment-summary-in-pr: always

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -27,15 +27,15 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Python 3.x
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.x"
 
     - name: Cache pip dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -78,15 +78,15 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Python 3.x
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.x"
 
     - name: Cache pip dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -112,7 +112,7 @@ jobs:
 
     - name: Upload Bandit SARIF to GitHub Code Scanning
       if: always()
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@v4
       with:
         sarif_file: bandit.sarif
         category: bandit
@@ -131,7 +131,7 @@ jobs:
 
     - name: Upload Snyk SARIF to GitHub Code Scanning
       if: always() && hashFiles('snyk.sarif') != ''
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@v4
       with:
         sarif_file: snyk.sarif
         category: snyk
@@ -150,15 +150,15 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Python 3.x
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.x"
 
     - name: Cache pip dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -175,13 +175,13 @@ jobs:
         python -m build
 
     - name: Upload Build Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: release-dists
         path: dist/*
     
     - name: Sign release
-      uses: actions/attest-build-provenance@v1
+      uses: actions/attest-build-provenance@v3
       with:
         subject-path: 'dist/*'
 
@@ -204,7 +204,7 @@ jobs:
 
     steps:
       - name: Retrieve release distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: release-dists
           path: dist/


### PR DESCRIPTION
## Summary

- Bumps every action that the v0.4.0 release run flagged as still running on the deprecated Node.js 20 runtime
- Picks the minimum major version that defaults to Node 24, to keep the diff small and the CI surface stable
- Also clears the separate "CodeQL Action v3 will be deprecated December 2026" notice by jumping `github/codeql-action/*` to v4

## Why now

Node.js 20 is forced off the default runner on **2026-06-02** and removed entirely on **2026-09-16**. We just shipped v0.4.0 successfully on the v4-era actions, so the upgrade window is now (low risk, no pending release).

## Version table

| Action | Was | Now | Notes |
|---|---|---|---|
| `actions/checkout` | v4 | v6 | Node 24 since v5; v6 is current latest with no behavioural changes for our use |
| `actions/setup-python` | v5 | v6 | Node 24 default |
| `actions/cache` | v4 | v5 | Node 24 default |
| `actions/upload-artifact` | v4 | v6 | v6 = Node 24 default. Skipped v7 (adds direct-upload, ESM — features we don't need) |
| `actions/download-artifact` | v4 | v7 | v7 = Node 24 default. Skipped v8 (hash-mismatch-error-by-default + ESM) |
| `actions/attest-build-provenance` | v1 | v3 | v3 bumps the underlying `actions/attest` to its Node 24 release |
| `actions/dependency-review-action` | v4 | v5 | Node 24 |
| `github/codeql-action/init` | v3 | v4 | Node 24 + clears the separate Dec 2026 deprecation notice |
| `github/codeql-action/analyze` | v3 | v4 | Same as above |
| `github/codeql-action/upload-sarif` | v3 | v4 | Same as above (×2 occurrences) |

## What's NOT changing

- `anthropics/claude-code-action@v1` — third-party, current major, not on the deprecation list
- `snyk/actions/python@master` — pinned to upstream master per Snyk's convention
- `pypa/gh-action-pypi-publish@release/v1` — uses a release branch, not Node-pinned, ran fine in the v0.4.0 publish

## Test plan

- [x] `python -c "import yaml; yaml.safe_load(...)"` parses every workflow file cleanly
- [x] No remaining `@v3`/`@v4`/`@v5` references on the bump list
- [ ] PR `test` job (Test, Scan, Build) green with the new versions
- [ ] PR `dependency-review` job green
- [ ] PR `CodeQL Advanced` job green
- [ ] PR `Dependency review` job green
- [ ] After merge: spot-check next release does not re-emit Node 20 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)