### PR TITLE
Fail loudly: exit code 2 on partial failures, stderr diagnostics, skipped-vs-failed counts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,13 +82,14 @@ python -m build
   - `_handle_database_list_command()` / `_handle_database_command(args)` - Managed-database list and update dispatch
   - `_resolve_firewall_config(args)` - Resolves config from args, file, or interactive selection
   - `_resolve_config_from_args(args)` / `_resolve_config_from_file(label, quiet)` / `_resolve_config_interactive(args)` - Config resolution helpers. `_resolve_config_from_file` prints the active firewall ID/label unless `quiet`.
-  - `_execute_firewall_operation(args, firewall_id, label)` - Dispatches update or remove
-  - `_run_implicit_batch_updates(args)` - After the firewall op, calls `update_all_lke_acls(..., implicit=True)` unless `--no-lke`, then `update_all_database_acls(..., implicit=True)` unless `--no-database`
-  - `main()` - Top-level dispatcher
+  - `_execute_firewall_operation(args, firewall_id, label)` - Dispatches update or remove, returns the operation's summary counts
+  - `_run_implicit_batch_updates(args)` - After the firewall op, calls `update_all_lke_acls(..., implicit=True)` unless `--no-lke`, then `update_all_database_acls(..., implicit=True)` unless `--no-database`; returns the total failed count
+  - `_failed_count(counts)` - Safely extracts `failed` from a summary-counts dict
+  - `_dispatch(args)` / `main()` - Top-level dispatcher; `main()` exits 2 when any target failed
 - **`firewall.py`**: Contains all business logic, API interactions, and validation
 - **`lke.py`**: LKE/LKE-E cluster enumeration and Control Plane ACL mutation
 - **`databases.py`**: Managed Database (MySQL/PostgreSQL) enumeration and `allow_list` mutation
-- **`output.py`**: Shared formatters that every deployment type (firewall, LKE, databases, any future type) uses so their output looks identical — target identifier: `<type> '<label>' (ID: <id>)`; lifecycle lines: preamble, result, noop, dry-run, skip, summary
+- **`output.py`**: Shared formatters that every deployment type (firewall, LKE, databases, any future type) uses so their output looks identical — target identifier: `<type> '<label>' (ID: <id>)`; lifecycle lines: preamble, result, noop, dry-run, skip, failure, summary. Skips are expected conditions (respect `--quiet`); failures are unexpected API errors (always printed). Both go to stderr. Summary shape: `Done. changed=X unchanged=Y skipped=S failed=Z total=W`
 
 ### Validation Functions (firewall.py)
 All inputs are validated before use:
@@ -123,10 +124,12 @@ LABEL_PATTERN = re.compile(r"^[a-zA-Z0-9_-]{1,32}$")
 IPV4_PATTERN = re.compile(r"^(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)$")
 ```
 
-### Error Handling Pattern (cli.py:215-223)
-- `ValueError`, `EOFError`, `KeyboardInterrupt` → Error message to stderr, exit code 1
+### Error Handling Pattern (cli.py `main()`)
+- `ValueError`, `EOFError`, `KeyboardInterrupt` → Error message to stderr (even in quiet mode), exit code 1
 - `FileNotFoundError` → Handled internally by `_resolve_firewall_config` (triggers interactive selection)
-- General exceptions → "Error" message to stderr (or re-raised in debug mode)
+- General exceptions → "Error" message to stderr (or re-raised in debug mode), exit code 1
+- Partial batch failure (some LKE clusters / databases errored but the run completed) → exit code 2
+- `--quiet` suppresses informational stdout only; failure diagnostics always print to stderr so cron runs leave a trail
 
 ## Testing Conventions
 
@@ -158,6 +161,7 @@ Tests are organized by class with descriptive names:
 - `TestCliDatabaseFlag` - Database-only mode (--database flag) tests
 - `TestCliDefaultDatabaseBehavior` - Default-on database update and --no-database opt-out
 - `TestCliListTableFormatting` - Dynamic column widths in --list output
+- `TestCliExitCodes` - Exit code 2 on partial batch failures; skips do not fail the run
 
 **test_lke.py** (unit tests for LKE / LKE-E ACL logic):
 - `TestListLkeClusters` - Paginated cluster listing, LKE-E `tier` detection
@@ -290,17 +294,19 @@ The tool uses the Linode API v4:
   the `{"acl": {...}}` envelope the PUT endpoint expects.
 - `update_all_lke_acls(debug, quiet, dry_run, remove, implicit=False)` -
   Orchestrator. Iterates clusters and applies `_apply_ip_to_acl` to add/remove
-  the current public IP. Per-cluster fetch/PUT failures are logged and counted
-  (`failed`) but do not abort the batch. When `implicit=True` (the default
-  firewall+LKE path driven by `main()`), the "No LKE clusters found" notice is
-  suppressed so users without any clusters see no extra output. Returns
-  `{"changed", "unchanged", "failed", "total"}`.
+  the current public IP. Per-cluster fetch/PUT failures are printed to stderr
+  (even in quiet mode) and counted (`failed`) but do not abort the batch. When
+  `implicit=True` (the default firewall+LKE path driven by `main()`), the
+  "No LKE clusters found" notice is suppressed so users without any clusters
+  see no extra output. Returns
+  `{"changed", "unchanged", "skipped", "failed", "total"}`; a non-zero
+  `failed` makes `main()` exit 2.
 
 ### Databases Module (`databases.py`)
 
 - `SUPPORTED_DB_ENGINES = ("mysql", "postgresql")` - engines whose `allow_list`
   this tool knows how to update; other engines surfaced by the listing endpoint
-  are reported as a per-database `failed` skip.
+  are reported as a per-database skip (`skipped`).
 - `list_databases()` - Paginated list of every managed database on the account
   via `/databases/instances`. The list response already contains `allow_list`,
   so the orchestrator does not need a per-database GET.
@@ -311,16 +317,19 @@ The tool uses the Linode API v4:
   list (does not mutate the input) plus `(changed, already_in_state)` flags.
 - `update_all_database_acls(debug, quiet, dry_run, remove, implicit=False)` -
   Orchestrator. Iterates databases and applies `_apply_ip_to_allow_list` to
-  add/remove the current public IP. Per-database PUT failures, unsupported
-  engines, and **VPC-attached databases** (`private_network` is non-null) are
-  logged and counted (`failed`) but do not abort the batch. We skip VPC-attached
-  databases because the public IP we detect from ipify cannot reach a VPC-only
-  endpoint — even with `public_access=true`, allow_list still gates external
-  connections, but they will not originate from the user's public IP. When
-  `implicit=True` (the default firewall+LKE+database path driven by `main()`),
-  the "No managed databases found" notice is suppressed so users without any
-  databases see no extra output. Returns
-  `{"changed", "unchanged", "failed", "total"}`.
+  add/remove the current public IP. Per-database PUT failures are printed to
+  stderr (even in quiet mode) and counted (`failed`); unsupported engines and
+  **VPC-attached databases** (`private_network` is non-null) are expected
+  conditions, printed to stderr unless `--quiet` and counted (`skipped`).
+  Neither aborts the batch, and only `failed` affects the exit code. We skip
+  VPC-attached databases because the public IP we detect from ipify cannot
+  reach a VPC-only endpoint — even with `public_access=true`, allow_list still
+  gates external connections, but they will not originate from the user's
+  public IP. When `implicit=True` (the default firewall+LKE+database path
+  driven by `main()`), the "No managed databases found" notice is suppressed
+  so users without any databases see no extra output. Returns
+  `{"changed", "unchanged", "skipped", "failed", "total"}`; a non-zero
+  `failed` makes `main()` exit 2.
 
 ## File Locations
 

--- a/README.md
+++ b/README.md
@@ -293,6 +293,16 @@ To automatically update your firewall rules (along with LKE / LKE-E Control Plan
 
 **Important**: Before using `--quiet` mode, you must have a valid configuration file (`~/.acc-fwu-config`) with your `firewall_id` and `label`. Interactive firewall selection is not available in quiet mode. Run `acc-fwu` interactively first to set up your configuration.
 
+### Exit Codes
+
+`acc-fwu` reports its outcome through the exit code, so cron and scripts can detect problems:
+
+- `0` — success (including no-op runs where everything was already up to date)
+- `1` — fatal error (invalid input, missing configuration, API/authentication failure)
+- `2` — the run completed, but one or more targets failed to update (e.g. a PUT to one LKE cluster or database errored while the others succeeded)
+
+Failures are always printed to `stderr`, even with `--quiet` — quiet mode silences informational output, not diagnostics — so failed cron runs leave a trail in your logs or cron mail. Expected skips (unsupported database engines, VPC-attached databases) are reported on `stderr` as `skipped` in the summary, respect `--quiet`, and do not affect the exit code.
+
 ## Configuration File
 
 The `acc-fwu` tool saves the `firewall_id` and `label` in a configuration file located at `~/.acc-fwu-config`. This file is:

--- a/src/acc_fwu/cli.py
+++ b/src/acc_fwu/cli.py
@@ -82,8 +82,8 @@ def _handle_lke_command(args):
     """Handle LKE Control Plane ACL operations across all clusters."""
     if args.list:
         _handle_lke_list_command()
-        return
-    update_all_lke_acls(
+        return None
+    return update_all_lke_acls(
         debug=args.debug,
         quiet=args.quiet,
         dry_run=args.dry_run,
@@ -120,8 +120,8 @@ def _handle_database_command(args):
     """Handle managed database allow_list operations across all databases."""
     if args.list:
         _handle_database_list_command()
-        return
-    update_all_database_acls(
+        return None
+    return update_all_database_acls(
         debug=args.debug,
         quiet=args.quiet,
         dry_run=args.dry_run,
@@ -225,14 +225,24 @@ def _resolve_firewall_config(args):
 def _execute_firewall_operation(args, firewall_id, label):
     """Execute the firewall operation (update or remove)."""
     if args.remove:
-        remove_firewall_rule(firewall_id, label, debug=args.debug, quiet=args.quiet, dry_run=args.dry_run)
-    else:
-        update_firewall_rule(firewall_id, label, debug=args.debug, quiet=args.quiet,
-                             dry_run=args.dry_run, add_ip=args.add)
+        return remove_firewall_rule(firewall_id, label, debug=args.debug, quiet=args.quiet, dry_run=args.dry_run)
+    return update_firewall_rule(firewall_id, label, debug=args.debug, quiet=args.quiet,
+                                dry_run=args.dry_run, add_ip=args.add)
+
+
+def _failed_count(counts):
+    """Extract the failed count from an operation's summary counts."""
+    if isinstance(counts, dict):
+        return counts.get("failed", 0)
+    return 0
 
 
 def _run_implicit_batch_updates(args):
-    """Run the LKE and managed database batch updates that follow a firewall change."""
+    """Run the LKE and managed database batch updates that follow a firewall change.
+
+    Returns:
+        int: Total number of failed targets across both batches.
+    """
     common = {
         "debug": args.debug,
         "quiet": args.quiet,
@@ -240,10 +250,34 @@ def _run_implicit_batch_updates(args):
         "remove": args.remove,
         "implicit": True,
     }
+    failed = 0
     if not args.no_lke:
-        update_all_lke_acls(**common)
+        failed += _failed_count(update_all_lke_acls(**common))
     if not args.no_database:
-        update_all_database_acls(**common)
+        failed += _failed_count(update_all_database_acls(**common))
+    return failed
+
+
+def _dispatch(args):
+    """Run the requested operations and return the number of failed targets."""
+    if args.lke or args.database:
+        # Explicit selectors: skip the firewall path and run whichever
+        # resource types were requested. Combining --lke and --database is
+        # supported and runs both in sequence.
+        failed = 0
+        if args.lke:
+            failed += _failed_count(_handle_lke_command(args))
+        if args.database:
+            failed += _failed_count(_handle_database_command(args))
+        return failed
+
+    if args.list:
+        _handle_list_command(args.debug)
+        return 0
+
+    firewall_id, label = _resolve_firewall_config(args)
+    failed = _failed_count(_execute_firewall_operation(args, firewall_id, label))
+    return failed + _run_implicit_batch_updates(args)
 
 
 def main():
@@ -252,32 +286,21 @@ def main():
 
     Parses command-line arguments and executes the appropriate firewall
     operation (update or remove rules).
+
+    Exit codes: 0 on success, 1 on a fatal error, 2 when the run completed
+    but one or more targets failed to update.
     """
     parser = _create_parser()
     args = parser.parse_args()
 
     try:
-        if args.lke or args.database:
-            # Explicit selectors: skip the firewall path and run whichever
-            # resource types were requested. Combining --lke and --database is
-            # supported and runs both in sequence.
-            if args.lke:
-                _handle_lke_command(args)
-            if args.database:
-                _handle_database_command(args)
-            return
-
-        if args.list:
-            _handle_list_command(args.debug)
-            return
-
-        firewall_id, label = _resolve_firewall_config(args)
-        _execute_firewall_operation(args, firewall_id, label)
-        _run_implicit_batch_updates(args)
+        if _dispatch(args):
+            sys.exit(2)
 
     except (ValueError, EOFError, KeyboardInterrupt) as e:
-        if not args.quiet:
-            print(f"Error: {e}", file=sys.stderr)
+        # Always print errors, even in quiet mode: --quiet silences
+        # informational output, not diagnostics.
+        print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
     except Exception as e:
         if args.debug:

--- a/src/acc_fwu/databases.py
+++ b/src/acc_fwu/databases.py
@@ -1,3 +1,5 @@
+import sys
+
 import requests
 
 from .firewall import (
@@ -10,6 +12,7 @@ from .firewall import (
 from .output import (
     format_batch_preamble,
     format_dry_run,
+    format_failure,
     format_noop,
     format_result,
     format_skip,
@@ -147,8 +150,12 @@ def _apply_ip_to_allow_list(allow_list, ip_with_mask, remove):
     return new_list, True, False
 
 
-def _commit_allow_list_change(database, db_label, new_list, headers, debug, quiet):
-    """PUT the updated allow_list, returning True on success."""
+def _commit_allow_list_change(database, db_label, new_list, headers, debug):
+    """PUT the updated allow_list, returning True on success.
+
+    Failures always print to stderr, even in quiet mode, so cron runs
+    leave a diagnostic trail.
+    """
     try:
         put_database_allow_list(
             database["id"],
@@ -159,8 +166,7 @@ def _commit_allow_list_change(database, db_label, new_list, headers, debug, quie
         )
         return True
     except requests.RequestException as e:
-        if not quiet:
-            print(format_skip(db_label, f"failed to update ({e})"))
+        print(format_failure(db_label, f"failed to update ({e})"), file=sys.stderr)
         return False
 
 
@@ -170,7 +176,7 @@ def _report_unchanged(db_label, ip_with_mask, remove, quiet):
     print(format_noop(ip_with_mask, db_label, remove=remove))
 
 
-def _check_skip_reason(database, db_label, quiet):
+def _check_skip_reason(database):
     """Return a skip reason string if the database should be skipped, else None.
 
     Per the Linode API, ``private_network`` is null when no VPC is configured
@@ -199,11 +205,13 @@ def _process_database(database, ip_with_mask, remove, debug, quiet, dry_run, hea
     """Apply the IP change to a single database's allow_list."""
     db_label = _format_database_label(database)
 
-    skip_reason = _check_skip_reason(database, db_label, quiet)
+    skip_reason = _check_skip_reason(database)
     if skip_reason is not None:
+        # Skips are expected steady-state conditions (unlike failures), so
+        # they respect --quiet; they still go to stderr as diagnostics.
         if not quiet:
-            print(format_skip(db_label, skip_reason))
-        return "failed"
+            print(format_skip(db_label, skip_reason), file=sys.stderr)
+        return "skipped"
 
     allow_list = database.get("allow_list", [])
     if debug:
@@ -219,7 +227,7 @@ def _process_database(database, ip_with_mask, remove, debug, quiet, dry_run, hea
             print(format_dry_run(ip_with_mask, db_label, remove=remove))
         return "changed"
 
-    if not _commit_allow_list_change(database, db_label, new_list, headers, debug, quiet):
+    if not _commit_allow_list_change(database, db_label, new_list, headers, debug):
         return "failed"
 
     if not quiet:
@@ -242,7 +250,9 @@ def update_all_database_acls(debug=False, quiet=False, dry_run=False, remove=Fal
             any databases see no extra output.
 
     Returns:
-        dict: Summary counts: ``changed``, ``unchanged``, ``failed``, ``total``.
+        dict: Summary counts: ``changed``, ``unchanged``, ``skipped``,
+        ``failed``, ``total``. Unsupported engines and VPC-attached databases
+        count as ``skipped``; API errors count as ``failed``.
     """
     headers = _auth_headers()
     databases = list_databases()
@@ -250,14 +260,14 @@ def update_all_database_acls(debug=False, quiet=False, dry_run=False, remove=Fal
     if not databases:
         if not quiet and not implicit:
             print("No managed databases found in your Linode account.")
-        return {"changed": 0, "unchanged": 0, "failed": 0, "total": 0}
+        return {"changed": 0, "unchanged": 0, "skipped": 0, "failed": 0, "total": 0}
 
     ip_with_mask = f"{get_public_ip()}/32"
 
     if not quiet:
         print(format_batch_preamble(ip_with_mask, "managed database(s)", len(databases), remove=remove))
 
-    counts = {"changed": 0, "unchanged": 0, "failed": 0, "total": len(databases)}
+    counts = {"changed": 0, "unchanged": 0, "skipped": 0, "failed": 0, "total": len(databases)}
     for database in databases:
         result = _process_database(database, ip_with_mask, remove, debug, quiet, dry_run, headers)
         counts[result] = counts.get(result, 0) + 1

--- a/src/acc_fwu/firewall.py
+++ b/src/acc_fwu/firewall.py
@@ -335,6 +335,10 @@ def remove_firewall_rule(firewall_id, label, debug=False, quiet=False, dry_run=F
         quiet (bool): If True, suppress output messages.
         dry_run (bool): If True, show what would be removed without making changes.
 
+    Returns:
+        dict: Summary counts: ``changed``, ``unchanged``, ``skipped``,
+        ``failed``, ``total``.
+
     Raises:
         ValueError: If firewall_id or label are invalid.
     """
@@ -372,14 +376,14 @@ def remove_firewall_rule(firewall_id, label, debug=False, quiet=False, dry_run=F
     rules_to_remove = len(existing_rules) - len(filtered_rules)
 
     if rules_to_remove == 0:
-        counts = {"changed": 0, "unchanged": 1, "failed": 0, "total": 1}
+        counts = {"changed": 0, "unchanged": 1, "skipped": 0, "failed": 0, "total": 1}
         if not quiet:
             print(format_noop(f"rules labeled '{label}'", target, remove=True))
             print(format_summary(counts))
         return counts
 
     if dry_run:
-        counts = {"changed": 1, "unchanged": 0, "failed": 0, "total": 1}
+        counts = {"changed": 1, "unchanged": 0, "skipped": 0, "failed": 0, "total": 1}
         if not quiet:
             print(format_dry_run(
                 f"{rules_to_remove} rule(s) labeled '{label}'",
@@ -402,7 +406,7 @@ def remove_firewall_rule(firewall_id, label, debug=False, quiet=False, dry_run=F
             print("Response content:", response.content)
         response.raise_for_status()
 
-    counts = {"changed": 1, "unchanged": 0, "failed": 0, "total": 1}
+    counts = {"changed": 1, "unchanged": 0, "skipped": 0, "failed": 0, "total": 1}
     if not quiet:
         print(format_result(
             f"{rules_to_remove} firewall rule(s) labeled '{label}'",
@@ -513,7 +517,7 @@ def update_firewall_rule(
     quiet: bool = False,
     dry_run: bool = False,
     add_ip: bool = False
-) -> None:
+) -> dict:
     """
     Update firewall rules by adding or updating rules with the current public IP address.
 
@@ -529,7 +533,8 @@ def update_firewall_rule(
         add_ip (bool): If True, append IP to existing rules instead of replacing.
 
     Returns:
-        None
+        dict: Summary counts: ``changed``, ``unchanged``, ``skipped``,
+        ``failed``, ``total``.
 
     Raises:
         ValueError: If firewall_id or label are invalid.
@@ -567,9 +572,9 @@ def update_firewall_rule(
 
     if dry_run:
         counts = (
-            {"changed": 0, "unchanged": 1, "failed": 0, "total": 1}
+            {"changed": 0, "unchanged": 1, "skipped": 0, "failed": 0, "total": 1}
             if _no_changes_needed(ip_already_exists, add_ip, updated_count, created_count)
-            else {"changed": 1, "unchanged": 0, "failed": 0, "total": 1}
+            else {"changed": 1, "unchanged": 0, "skipped": 0, "failed": 0, "total": 1}
         )
         if not quiet:
             _print_dry_run_message(
@@ -579,7 +584,7 @@ def update_firewall_rule(
         return counts
 
     if _no_changes_needed(ip_already_exists, add_ip, updated_count, created_count):
-        counts = {"changed": 0, "unchanged": 1, "failed": 0, "total": 1}
+        counts = {"changed": 0, "unchanged": 1, "skipped": 0, "failed": 0, "total": 1}
         if not quiet:
             print(format_noop(ip_with_mask, target))
             print(format_summary(counts))
@@ -601,7 +606,7 @@ def update_firewall_rule(
             print("Response content:", response.content)
         response.raise_for_status()
 
-    counts = {"changed": 1, "unchanged": 0, "failed": 0, "total": 1}
+    counts = {"changed": 1, "unchanged": 0, "skipped": 0, "failed": 0, "total": 1}
     if not quiet:
         _print_result_message(ip_with_mask, target)
         print(format_summary(counts))

--- a/src/acc_fwu/lke.py
+++ b/src/acc_fwu/lke.py
@@ -1,3 +1,5 @@
+import sys
+
 import requests
 
 from .firewall import (
@@ -10,9 +12,9 @@ from .firewall import (
 from .output import (
     format_batch_preamble,
     format_dry_run,
+    format_failure,
     format_noop,
     format_result,
-    format_skip,
     format_summary,
     format_target,
 )
@@ -169,24 +171,30 @@ def _apply_ip_to_acl(acl, ip_with_mask, remove):
     return new_acl, True, False
 
 
-def _fetch_acl_safe(cluster, cluster_label, quiet, headers):
-    """Fetch ACL for a cluster, returning None on HTTP failure."""
+def _fetch_acl_safe(cluster, cluster_label, headers):
+    """Fetch ACL for a cluster, returning None on HTTP failure.
+
+    Failures always print to stderr, even in quiet mode, so cron runs
+    leave a diagnostic trail.
+    """
     try:
         return get_lke_acl(cluster["id"], headers=headers)
     except requests.RequestException as e:
-        if not quiet:
-            print(format_skip(cluster_label, f"failed to fetch ACL ({e})"))
+        print(format_failure(cluster_label, f"failed to fetch ACL ({e})"), file=sys.stderr)
         return None
 
 
-def _commit_acl_change(cluster, cluster_label, new_acl, headers, debug, quiet):
-    """PUT the updated ACL, returning True on success."""
+def _commit_acl_change(cluster, cluster_label, new_acl, headers, debug):
+    """PUT the updated ACL, returning True on success.
+
+    Failures always print to stderr, even in quiet mode, so cron runs
+    leave a diagnostic trail.
+    """
     try:
         put_lke_acl(cluster["id"], new_acl, headers=headers, debug=debug)
         return True
     except requests.RequestException as e:
-        if not quiet:
-            print(format_skip(cluster_label, f"failed to update ({e})"))
+        print(format_failure(cluster_label, f"failed to update ({e})"), file=sys.stderr)
         return False
 
 
@@ -206,7 +214,7 @@ def _process_cluster(cluster, ip_with_mask, remove, debug, quiet, dry_run, heade
     """Apply the IP change to a single cluster's Control Plane ACL."""
     cluster_label = _format_cluster_label(cluster)
 
-    acl = _fetch_acl_safe(cluster, cluster_label, quiet, headers)
+    acl = _fetch_acl_safe(cluster, cluster_label, headers)
     if acl is None:
         return "failed"
 
@@ -225,7 +233,7 @@ def _process_cluster(cluster, ip_with_mask, remove, debug, quiet, dry_run, heade
 
     _maybe_warn_disabled(acl, cluster_label, remove, quiet)
 
-    if not _commit_acl_change(cluster, cluster_label, new_acl, headers, debug, quiet):
+    if not _commit_acl_change(cluster, cluster_label, new_acl, headers, debug):
         return "failed"
 
     if not quiet:
@@ -247,7 +255,8 @@ def update_all_lke_acls(debug=False, quiet=False, dry_run=False, remove=False, i
             "No LKE clusters found" notice so users without LKE see no noise.
 
     Returns:
-        dict: Summary counts: ``changed``, ``unchanged``, ``failed``, ``total``.
+        dict: Summary counts: ``changed``, ``unchanged``, ``skipped``,
+        ``failed``, ``total``.
     """
     headers = _auth_headers()
     clusters = list_lke_clusters()
@@ -255,14 +264,14 @@ def update_all_lke_acls(debug=False, quiet=False, dry_run=False, remove=False, i
     if not clusters:
         if not quiet and not implicit:
             print("No LKE clusters found in your Linode account.")
-        return {"changed": 0, "unchanged": 0, "failed": 0, "total": 0}
+        return {"changed": 0, "unchanged": 0, "skipped": 0, "failed": 0, "total": 0}
 
     ip_with_mask = f"{get_public_ip()}/32"
 
     if not quiet:
         print(format_batch_preamble(ip_with_mask, "LKE cluster(s)", len(clusters), remove=remove))
 
-    counts = {"changed": 0, "unchanged": 0, "failed": 0, "total": len(clusters)}
+    counts = {"changed": 0, "unchanged": 0, "skipped": 0, "failed": 0, "total": len(clusters)}
     for cluster in clusters:
         result = _process_cluster(cluster, ip_with_mask, remove, debug, quiet, dry_run, headers)
         counts[result] = counts.get(result, 0) + 1

--- a/src/acc_fwu/output.py
+++ b/src/acc_fwu/output.py
@@ -12,7 +12,12 @@ vocabulary is:
     noop:      "<ip> already present on <target>, no changes needed"
     dry-run:   "[DRY RUN] Would add <ip> on <target>"
     skip:      "Skipping <target>: <reason>"
-    summary:   "Done. changed=X unchanged=Y failed=Z total=W"
+    failure:   "Error on <target>: <reason>"
+    summary:   "Done. changed=X unchanged=Y skipped=S failed=Z total=W"
+
+Skips are expected conditions (unsupported engine, VPC-attached database) and
+respect --quiet; failures are unexpected API errors and are always printed so
+they reach cron logs even in quiet mode. Both belong on stderr.
 """
 
 
@@ -79,11 +84,17 @@ def format_skip(target, reason):
     return f"Skipping {target}: {reason}"
 
 
+def format_failure(target, reason):
+    """Render a failure line when an operation on a target errored."""
+    return f"Error on {target}: {reason}"
+
+
 def format_summary(counts):
     """Render the end-of-stage counter summary."""
     return (
         f"Done. changed={counts.get('changed', 0)} "
         f"unchanged={counts.get('unchanged', 0)} "
+        f"skipped={counts.get('skipped', 0)} "
         f"failed={counts.get('failed', 0)} "
         f"total={counts.get('total', 0)}"
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -210,8 +210,8 @@ class TestCliNewOptions:
             "12345", "Default-Label", debug=True, quiet=False, dry_run=False, add_ip=False
         )
 
-    def test_main_quiet_mode_suppresses_config_error(self, monkeypatch, capsys):
-        """Test that --quiet suppresses config file not found message."""
+    def test_main_quiet_mode_still_reports_config_error(self, monkeypatch, capsys):
+        """--quiet silences stdout, but the fatal error still reaches stderr."""
         mock_load_config = mock.MagicMock(side_effect=FileNotFoundError)
 
         monkeypatch.setattr("acc_fwu.cli.load_config", mock_load_config)
@@ -222,8 +222,9 @@ class TestCliNewOptions:
 
         assert exc_info.value.code == 1
         captured = capsys.readouterr()
-        # Output should be empty in quiet mode
+        # stdout stays empty in quiet mode, but the diagnostic goes to stderr
         assert captured.out == ""
+        assert "Error:" in captured.err
 
 
 class TestCliValidation:
@@ -852,3 +853,77 @@ class TestCliListTableFormatting:
                 break
         else:
             pytest.fail(f"long label {long_label!r} not found in output:\n{captured.out}")
+
+
+class TestCliExitCodes:
+    """Tests for exit code 2 when batch updates report failed targets."""
+
+    FAILED = {"changed": 0, "unchanged": 0, "skipped": 0, "failed": 1, "total": 1}
+    CLEAN = {"changed": 1, "unchanged": 0, "skipped": 0, "failed": 0, "total": 1}
+
+    def _setup_firewall_path(self, monkeypatch, lke_counts, db_counts):
+        monkeypatch.setattr("acc_fwu.cli.load_config",
+                            mock.MagicMock(return_value=("12345", "Label")))
+        monkeypatch.setattr("acc_fwu.cli.update_firewall_rule",
+                            mock.MagicMock(return_value=self.CLEAN))
+        monkeypatch.setattr("acc_fwu.cli.update_all_lke_acls",
+                            mock.MagicMock(return_value=lke_counts))
+        monkeypatch.setattr("acc_fwu.cli.update_all_database_acls",
+                            mock.MagicMock(return_value=db_counts))
+
+    def test_implicit_lke_failure_exits_2(self, monkeypatch):
+        """A failed cluster in the implicit LKE batch must exit 2, not 0."""
+        self._setup_firewall_path(monkeypatch, self.FAILED, self.CLEAN)
+        monkeypatch.setattr(sys, "argv", ["acc-fwu"])
+
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+        assert exc_info.value.code == 2
+
+    def test_implicit_database_failure_exits_2(self, monkeypatch):
+        """A failed database in the implicit batch must exit 2, not 0."""
+        self._setup_firewall_path(monkeypatch, self.CLEAN, self.FAILED)
+        monkeypatch.setattr(sys, "argv", ["acc-fwu"])
+
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+        assert exc_info.value.code == 2
+
+    def test_all_clean_exits_normally(self, monkeypatch):
+        """No failures anywhere means a normal (0) exit."""
+        self._setup_firewall_path(monkeypatch, self.CLEAN, self.CLEAN)
+        monkeypatch.setattr(sys, "argv", ["acc-fwu"])
+
+        main()  # must not raise SystemExit
+
+    def test_skipped_targets_do_not_fail_the_run(self, monkeypatch):
+        """Skipped databases (VPC/unsupported engine) are not failures."""
+        skipped = {"changed": 0, "unchanged": 0, "skipped": 2, "failed": 0, "total": 2}
+        self._setup_firewall_path(monkeypatch, self.CLEAN, skipped)
+        monkeypatch.setattr(sys, "argv", ["acc-fwu"])
+
+        main()  # must not raise SystemExit
+
+    def test_explicit_lke_failure_exits_2(self, monkeypatch):
+        """--lke with a failed cluster must exit 2."""
+        monkeypatch.setattr("acc_fwu.cli.update_all_lke_acls",
+                            mock.MagicMock(return_value=self.FAILED))
+        monkeypatch.setattr(sys, "argv", ["acc-fwu", "--lke"])
+
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+        assert exc_info.value.code == 2
+
+    def test_explicit_database_failure_exits_2(self, monkeypatch):
+        """--database with a failed database must exit 2."""
+        monkeypatch.setattr("acc_fwu.cli.update_all_database_acls",
+                            mock.MagicMock(return_value=self.FAILED))
+        monkeypatch.setattr(sys, "argv", ["acc-fwu", "--database"])
+
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+        assert exc_info.value.code == 2

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -188,7 +188,7 @@ class TestUpdateAllDatabaseAcls:
 
         counts = update_all_database_acls(quiet=True)
 
-        assert counts == {"changed": 2, "unchanged": 0, "failed": 0, "total": 2}
+        assert counts == {"changed": 2, "unchanged": 0, "skipped": 0, "failed": 0, "total": 2}
         assert put_mock.call_count == 2
         # First call: db id=1 mysql, allow_list should now contain the IP
         assert put_mock.call_args_list[0][0][0] == 1
@@ -287,14 +287,16 @@ class TestUpdateAllDatabaseAcls:
         counts = update_all_database_acls(quiet=False)
 
         assert counts["changed"] == 1
-        assert counts["failed"] == 2
+        assert counts["skipped"] == 2
+        assert counts["failed"] == 0
         # Only the non-VPC database is updated
         put_mock.assert_called_once()
         assert put_mock.call_args[0][0] == 3
+        # Skip notices are diagnostics and go to stderr
         captured = capsys.readouterr()
-        assert "attached to VPC" in captured.out
-        assert "vpc_id=42" in captured.out
-        assert "vpc_id=99" in captured.out
+        assert "attached to VPC" in captured.err
+        assert "vpc_id=42" in captured.err
+        assert "vpc_id=99" in captured.err
 
     def test_vpc_skip_respects_quiet(self, monkeypatch, capsys):
         databases = [
@@ -305,10 +307,13 @@ class TestUpdateAllDatabaseAcls:
 
         counts = update_all_database_acls(quiet=True)
 
-        assert counts["failed"] == 1
+        assert counts["skipped"] == 1
+        assert counts["failed"] == 0
         put_mock.assert_not_called()
+        # Skips are expected conditions, so quiet silences them entirely
         captured = capsys.readouterr()
         assert captured.out == ""
+        assert captured.err == ""
 
     def test_missing_private_network_field_treated_as_non_vpc(self, monkeypatch):
         """Older API responses without the private_network field should not be
@@ -324,7 +329,7 @@ class TestUpdateAllDatabaseAcls:
         assert counts["failed"] == 0
         put_mock.assert_called_once()
 
-    def test_unsupported_engine_is_failed(self, monkeypatch, capsys):
+    def test_unsupported_engine_is_skipped(self, monkeypatch, capsys):
         databases = [
             {"id": 1, "label": "redis", "engine": "redis", "allow_list": []},
             {"id": 2, "label": "primary", "engine": "mysql", "allow_list": []},
@@ -333,13 +338,14 @@ class TestUpdateAllDatabaseAcls:
 
         counts = update_all_database_acls(quiet=False)
 
-        assert counts["failed"] == 1
+        assert counts["skipped"] == 1
+        assert counts["failed"] == 0
         assert counts["changed"] == 1
         # Only the supported engine is updated
         put_mock.assert_called_once()
         assert put_mock.call_args[0][1] == "mysql"
         captured = capsys.readouterr()
-        assert "unsupported engine" in captured.out
+        assert "unsupported engine" in captured.err
 
     def test_put_failure_is_counted(self, monkeypatch, capsys):
         databases = [{"id": 1, "label": "primary", "engine": "mysql",
@@ -357,7 +363,8 @@ class TestUpdateAllDatabaseAcls:
         assert counts["failed"] == 1
         assert counts["changed"] == 0
         captured = capsys.readouterr()
-        assert "failed to update" in captured.out
+        assert "Error on mysql database 'primary' (ID: 1)" in captured.err
+        assert "failed to update" in captured.err
 
     def test_summary_printed_when_not_quiet(self, monkeypatch, capsys):
         databases = [{"id": 1, "label": "primary", "engine": "mysql",
@@ -389,3 +396,7 @@ class TestUpdateAllDatabaseAcls:
         assert counts["changed"] == 1
         assert counts["failed"] == 1
         assert counts["total"] == 2
+        # The failure is still reported on stderr despite quiet mode
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert "Error on mysql database 'primary' (ID: 1)" in captured.err

--- a/tests/test_lke.py
+++ b/tests/test_lke.py
@@ -191,7 +191,7 @@ class TestUpdateAllLkeAcls:
 
         counts = update_all_lke_acls(quiet=True)
 
-        assert counts == {"changed": 2, "unchanged": 0, "failed": 0, "total": 2}
+        assert counts == {"changed": 2, "unchanged": 0, "skipped": 0, "failed": 0, "total": 2}
         assert put_mock.call_count == 2
         sent = put_mock.call_args_list[0][0][1]
         assert "9.9.9.9/32" in sent["addresses"]["ipv4"]
@@ -291,8 +291,10 @@ class TestUpdateAllLkeAcls:
         assert counts["changed"] == 1
         assert counts["failed"] == 1
         put_mock.assert_called_once()
+        captured = capsys.readouterr()
+        assert "failed to fetch ACL" in captured.err
 
-    def test_put_failure_is_counted(self, monkeypatch):
+    def test_put_failure_is_counted(self, monkeypatch, capsys):
         clusters = [{"id": 1, "label": "std", "tier": "standard"}]
         acls = {1: {"enabled": True, "addresses": {"ipv4": [], "ipv6": []}}}
         monkeypatch.setattr("acc_fwu.lke.get_api_token", mock.Mock(return_value="test-token"))
@@ -308,3 +310,9 @@ class TestUpdateAllLkeAcls:
 
         assert counts["failed"] == 1
         assert counts["changed"] == 0
+        # Failures are diagnostics: printed to stderr even in quiet mode,
+        # while stdout stays silent.
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert "Error on LKE 'std' (ID: 1)" in captured.err
+        assert "failed to update" in captured.err

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -7,6 +7,7 @@ from acc_fwu.output import (
     format_batch_preamble,
     format_dry_run,
     format_dry_run_noop,
+    format_failure,
     format_noop,
     format_preamble,
     format_result,
@@ -101,15 +102,28 @@ class TestSkip:
         assert format_skip(t, "timed out") == "Skipping LKE 'broken' (ID: 99): timed out"
 
 
+class TestFailure:
+    def test_failure_with_reason(self):
+        t = format_target("LKE", "broken", 99)
+        assert format_failure(t, "failed to update (500)") == (
+            "Error on LKE 'broken' (ID: 99): failed to update (500)"
+        )
+
+
 class TestSummary:
     def test_all_counts(self):
         assert format_summary(
-            {"changed": 2, "unchanged": 1, "failed": 0, "total": 3}
-        ) == "Done. changed=2 unchanged=1 failed=0 total=3"
+            {"changed": 2, "unchanged": 1, "skipped": 0, "failed": 0, "total": 3}
+        ) == "Done. changed=2 unchanged=1 skipped=0 failed=0 total=3"
+
+    def test_skipped_count(self):
+        assert format_summary(
+            {"changed": 1, "unchanged": 0, "skipped": 2, "failed": 1, "total": 4}
+        ) == "Done. changed=1 unchanged=0 skipped=2 failed=1 total=4"
 
     def test_missing_counts_default_zero(self):
         assert format_summary({"total": 1}) == (
-            "Done. changed=0 unchanged=0 failed=0 total=1"
+            "Done. changed=0 unchanged=0 skipped=0 failed=0 total=1"
         )
 
 


### PR DESCRIPTION
## Problem

`acc-fwu` is designed to run from cron (`--quiet` exists for exactly that), but failures in the LKE ACL and database allow_list batches were invisible to automation:

- `update_all_lke_acls` / `update_all_database_acls` counted failures in their summaries, but `main()` ignored the return values — the process exited 0 even when every target failed to update.
- Every failure message was gated behind `if not quiet:` and printed to stdout, so a `--quiet` cron run that failed left no trace anywhere.
- Expected skips (unsupported database engines, VPC-attached databases) were counted as `failed`, so a user with one VPC-attached database saw `failed=1` on every run — and would have wrongly failed the run once exit codes reflected failures.

## Changes

**Exit codes** (`cli.py`)
- `main()` now exits `2` when the run completes but one or more targets failed to update. Fatal errors remain exit `1`, success (including no-ops and skips) remains `0`.
- Firewall, LKE, and database operations return their summary counts up through a new `_dispatch()` helper (also keeps `main()` under the flake8 complexity-10 limit).

**Stderr diagnostics** (`output.py`, `lke.py`, `databases.py`, `cli.py`)
- New `format_failure()` formatter: `Error on <target>: <reason>`. API failures (fetch/PUT errors) print to **stderr unconditionally**, even with `--quiet` — quiet mode silences informational output, not diagnostics.
- Fatal errors caught in `main()` are likewise no longer suppressed by `--quiet`.
- Skip notices moved from stdout to stderr.

**Skipped vs failed** (`databases.py`, `output.py`, all modules)
- Unsupported engines and VPC-attached databases now count as `skipped` instead of `failed`. Skips are expected steady-state conditions: they respect `--quiet` and do not affect the exit code.
- All summary lines and count dicts gain a `skipped` field: `Done. changed=X unchanged=Y skipped=S failed=Z total=W`.
- The misleading `Skipping <target>: failed to update (...)` message on PUT errors is replaced by the failure formatter.

**Docs**: README gains an "Exit Codes" section; CLAUDE.md updated to match the new counts, streams, and exit-code contract.

## Testing

- 180 tests pass (172 existing + 8 new/extended), flake8 clean including `--max-complexity=10`.
- New `TestCliExitCodes` class covers exit 2 for implicit and explicit batch failures, and that skips/clean runs exit normally.
- Verified end-to-end with a mocked Linode API (real `main()` + real orchestrators): a failing LKE PUT plus a VPC-attached database produces clean lifecycle stdout, `Error on LKE ... (500)` and the VPC skip on stderr, and exit code 2; with `--quiet`, stdout is empty, the failure still reaches stderr, the skip is silenced, and the exit code is still 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RaoNSaAsRd1eHdHkMZKUmf

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaoNSaAsRd1eHdHkMZKUmf)_