### PR TITLE
Add --lke-enable-acl and --db-enable-firewall switches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,8 +14,8 @@ This file provides guidance for AI assistants working with the `acc-fwu` (Akamai
 - Input validation for security
 - Interactive firewall selection (lists available firewalls)
 - Add mode for multiple IP addresses (travel use case)
-- LKE / LKE-E Control Plane ACL automation runs by default alongside firewall updates (`--no-lke` to skip, `--lke` for LKE-only mode)
-- Managed Database (MySQL/PostgreSQL) `allow_list` automation runs by default alongside firewall updates (`--no-database` to skip, `--database` for database-only mode)
+- LKE / LKE-E Control Plane ACL automation runs by default alongside firewall updates (`--no-lke` to skip, `--lke` for LKE-only mode, `--lke-enable-acl` to enable a disabled Control Plane ACL as the IP is added)
+- Managed Database (MySQL/PostgreSQL) `allow_list` automation runs by default alongside firewall updates (`--no-database` to skip, `--database` for database-only mode, `--db-enable-firewall` to strip open ranges so the allow_list actually restricts access)
 - Prints the active firewall ID/label when loaded from config so the user sees which firewall is being touched
 
 ## Codebase Structure
@@ -292,9 +292,16 @@ The tool uses the Linode API v4:
   cluster uniformly.
 - `put_lke_acl(cluster_id, acl, headers=None, debug=False)` - Wraps the ACL in
   the `{"acl": {...}}` envelope the PUT endpoint expects.
-- `update_all_lke_acls(debug, quiet, dry_run, remove, implicit=False)` -
+- `_apply_ip_to_acl(acl, ip_with_mask, remove, enable_acl=False)` - Pure address
+  math. When `enable_acl=True` and adding, a disabled ACL is flipped
+  `enabled: true`; that flip counts as a change on its own (so a disabled ACL
+  that already contains the IP is still `changed`). `enable_acl` is ignored in
+  remove mode.
+- `update_all_lke_acls(debug, quiet, dry_run, remove, implicit=False, enable_acl=False)` -
   Orchestrator. Iterates clusters and applies `_apply_ip_to_acl` to add/remove
-  the current public IP. Per-cluster fetch/PUT failures are printed to stderr
+  the current public IP. `enable_acl` (wired from `--lke-enable-acl`) enables a
+  disabled Control Plane ACL as the IP is added and suppresses the
+  "ACL is disabled" warning for that cluster. Per-cluster fetch/PUT failures are printed to stderr
   (even in quiet mode) and counted (`failed`) but do not abort the batch. When
   `implicit=True` (the default firewall+LKE path driven by `main()`), the
   "No LKE clusters found" notice is suppressed so users without any clusters
@@ -307,17 +314,28 @@ The tool uses the Linode API v4:
 - `SUPPORTED_DB_ENGINES = ("mysql", "postgresql")` - engines whose `allow_list`
   this tool knows how to update; other engines surfaced by the listing endpoint
   are reported as a per-database skip (`skipped`).
+- `OPEN_ALLOW_LIST_RANGES = ("0.0.0.0/0", "::/0")` - "open to the world" ranges.
+  Managed databases have no firewall on/off toggle — the `allow_list` is the
+  firewall, and one of these entries effectively disables it.
+  `--db-enable-firewall` strips them.
 - `list_databases()` - Paginated list of every managed database on the account
   via `/databases/instances`. The list response already contains `allow_list`,
   so the orchestrator does not need a per-database GET.
 - `put_database_allow_list(database_id, engine, allow_list, headers=None,
   debug=False)` - PUTs to `/databases/{engine}/instances/{database_id}` with the
   `{"allow_list": [...]}` body. The new list overwrites the existing one.
-- `_apply_ip_to_allow_list(allow_list, ip_with_mask, remove)` - Returns a fresh
-  list (does not mutate the input) plus `(changed, already_in_state)` flags.
-- `update_all_database_acls(debug, quiet, dry_run, remove, implicit=False)` -
+- `_apply_ip_to_allow_list(allow_list, ip_with_mask, remove, enable_firewall=False)`
+  - Returns a fresh list (does not mutate the input) plus
+  `(changed, already_in_state)` flags. When `enable_firewall=True` and adding,
+  open ranges (`OPEN_ALLOW_LIST_RANGES`) are stripped; stripping counts as a
+  change on its own. The IP is always appended before open ranges are removed,
+  so the resulting list is never empty. `enable_firewall` is ignored in remove
+  mode.
+- `update_all_database_acls(debug, quiet, dry_run, remove, implicit=False, enable_firewall=False)` -
   Orchestrator. Iterates databases and applies `_apply_ip_to_allow_list` to
-  add/remove the current public IP. Per-database PUT failures are printed to
+  add/remove the current public IP. `enable_firewall` (wired from
+  `--db-enable-firewall`) strips open ranges so the allow_list actually
+  restricts access. Per-database PUT failures are printed to
   stderr (even in quiet mode) and counted (`failed`); unsupported engines and
   **VPC-attached databases** (`private_network` is non-null) are expected
   conditions, printed to stderr unless `--quiet` and counted (`skipped`).

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ A tool to automatically update the [Akamai Connected Cloud (ACC) / Linode](https
 - Secure configuration file storage (owner-only permissions)
 - **Interactive firewall selection** - List and choose from available firewalls
 - **Add mode** - Accumulate multiple IP addresses (ideal for traveling)
-- **LKE Control Plane ACL automation** - Every run also syncs your public IP into every LKE and LKE-E cluster's Control Plane ACL (opt-out with `--no-lke`; use `--lke` for LKE-only mode)
-- **Managed Database allow_list automation** - Every run also syncs your public IP into every MySQL/PostgreSQL Managed Database `allow_list` (opt-out with `--no-database`; use `--database` for database-only mode)
+- **LKE Control Plane ACL automation** - Every run also syncs your public IP into every LKE and LKE-E cluster's Control Plane ACL (opt-out with `--no-lke`; use `--lke` for LKE-only mode; enable a disabled ACL with `--lke-enable-acl`)
+- **Managed Database allow_list automation** - Every run also syncs your public IP into every MySQL/PostgreSQL Managed Database `allow_list` (opt-out with `--no-database`; use `--database` for database-only mode; lock down open ranges with `--db-enable-firewall`)
 - **Active firewall indicator** - When the config file is used, `acc-fwu` prints the firewall ID and label it's operating on
 
 ## Prerequisites
@@ -89,7 +89,7 @@ This will:
 ### Command-Line Options
 
 ```
-usage: acc-fwu [-h] [--firewall_id FIREWALL_ID] [--label LABEL] [-d] [-r] [-a] [-l] [--lke] [--no-lke] [--database] [--no-database] [-q] [--dry-run] [-v]
+usage: acc-fwu [-h] [--firewall_id FIREWALL_ID] [--label LABEL] [-d] [-r] [-a] [-l] [--lke] [--no-lke] [--lke-enable-acl] [--database] [--no-database] [--db-enable-firewall] [-q] [--dry-run] [-v]
 
 Create, update, or remove Akamai Connected Cloud (Linode) firewall rules with your current IP address.
 
@@ -106,10 +106,16 @@ options:
                         Adds (or removes with -r) your current public IP to every cluster's ACL.
   --no-lke              Skip the default LKE/LKE-E Control Plane ACL update.
                         By default, acc-fwu updates firewall rules, LKE ACLs, and managed database allow_lists.
+  --lke-enable-acl      When updating LKE/LKE-E clusters, also enable the Control Plane ACL
+                        (firewall) if it is currently disabled, so the added IP is enforced.
+                        No effect with -r/--remove.
   --database            Target managed database allow_lists only; skip firewall rules.
                         Adds (or removes with -r) your current public IP to every managed database's allow_list.
   --no-database         Skip the default managed database allow_list update.
                         By default, acc-fwu updates firewall rules, LKE ACLs, and managed database allow_lists.
+  --db-enable-firewall  When updating managed databases, remove open ranges (0.0.0.0/0, ::/0)
+                        from the allow_list so only explicitly-allowed IPs can connect.
+                        No effect with -r/--remove.
   -q, --quiet           Suppress output messages (useful for cron/scripting).
   --dry-run             Show what would be done without making any changes.
   -v, --version         show program's version number and exit
@@ -229,6 +235,16 @@ acc-fwu --lke --dry-run
 acc-fwu --lke --remove
 ```
 
+**Enable the Control Plane ACL (firewall) as you add your IP:**
+
+By default the `enabled` state is preserved, so an IP added to a *disabled* ACL is stored but not enforced. Pass `--lke-enable-acl` to switch the firewall on for any cluster whose ACL is currently disabled, so the added IP takes effect immediately:
+
+```bash
+acc-fwu --lke --lke-enable-acl
+```
+
+This works in the default combined run too (e.g. `acc-fwu --lke-enable-acl`). It has no effect with `-r/--remove` — enabling a firewall while withdrawing your own IP would be contradictory.
+
 **Run silently in a cron job:**
 
 ```bash
@@ -276,6 +292,16 @@ acc-fwu --database --dry-run
 ```bash
 acc-fwu --database --remove
 ```
+
+**Lock down the firewall as you add your IP:**
+
+Managed databases have no separate firewall on/off toggle — the `allow_list` *is* the firewall, and an entry of `0.0.0.0/0` (or `::/0`) leaves it open to the whole internet. Pass `--db-enable-firewall` to strip those open ranges while adding your IP, so only explicitly-allowed addresses can connect:
+
+```bash
+acc-fwu --database --db-enable-firewall
+```
+
+This works in the default combined run too (e.g. `acc-fwu --db-enable-firewall`). It has no effect with `-r/--remove`. Because your IP is always added before the open ranges are removed, the `allow_list` is never left empty (which would block all connections).
 
 Databases on engines other than `mysql` or `postgresql` are reported as a per-database skip. Failures on individual databases are logged and counted in the final summary but do not abort the run.
 

--- a/src/acc_fwu/cli.py
+++ b/src/acc_fwu/cli.py
@@ -88,6 +88,7 @@ def _handle_lke_command(args):
         quiet=args.quiet,
         dry_run=args.dry_run,
         remove=args.remove,
+        enable_acl=args.lke_enable_acl,
     )
 
 
@@ -126,6 +127,7 @@ def _handle_database_command(args):
         quiet=args.quiet,
         dry_run=args.dry_run,
         remove=args.remove,
+        enable_firewall=args.db_enable_firewall,
     )
 
 
@@ -195,6 +197,10 @@ def _create_parser():
                         help="Skip the default LKE/LKE-E Control Plane ACL update. "
                              "By default, acc-fwu updates firewall rules, LKE ACLs, "
                              "and managed database allow_lists.")
+    parser.add_argument("--lke-enable-acl", action="store_true",
+                        help="When updating LKE/LKE-E clusters, also enable the Control "
+                             "Plane ACL (firewall) if it is currently disabled, so the "
+                             "added IP is actually enforced. No effect with -r/--remove.")
     parser.add_argument("--database", action="store_true",
                         help="Target managed database allow_lists; skip firewall rules. "
                              "Adds (or removes with -r) your current public IP to every "
@@ -203,6 +209,10 @@ def _create_parser():
                         help="Skip the default managed database allow_list update. "
                              "By default, acc-fwu updates firewall rules, LKE ACLs, "
                              "and managed database allow_lists.")
+    parser.add_argument("--db-enable-firewall", action="store_true",
+                        help="When updating managed databases, remove open ranges "
+                             "(0.0.0.0/0, ::/0) from the allow_list so only "
+                             "explicitly-allowed IPs can connect. No effect with -r/--remove.")
     parser.add_argument("-q", "--quiet", action="store_true",
                         help="Suppress output messages (useful for cron/scripting).")
     parser.add_argument("--dry-run", action="store_true",
@@ -252,9 +262,11 @@ def _run_implicit_batch_updates(args):
     }
     failed = 0
     if not args.no_lke:
-        failed += _failed_count(update_all_lke_acls(**common))
+        failed += _failed_count(update_all_lke_acls(enable_acl=args.lke_enable_acl, **common))
     if not args.no_database:
-        failed += _failed_count(update_all_database_acls(**common))
+        failed += _failed_count(
+            update_all_database_acls(enable_firewall=args.db_enable_firewall, **common)
+        )
     return failed
 
 

--- a/src/acc_fwu/databases.py
+++ b/src/acc_fwu/databases.py
@@ -131,11 +131,6 @@ def _format_database_label(database):
     return format_target(type_name, database.get("label", ""), database["id"])
 
 
-def _has_open_range(allow_list):
-    """True if the allow_list contains an open-to-the-world range."""
-    return any(ip in OPEN_ALLOW_LIST_RANGES for ip in (allow_list or []))
-
-
 def _apply_ip_to_allow_list(allow_list, ip_with_mask, remove, enable_firewall=False):
     """
     Apply the IP change to an allow_list in a copy-safe manner.

--- a/src/acc_fwu/databases.py
+++ b/src/acc_fwu/databases.py
@@ -28,6 +28,12 @@ LINODE_DATABASES_LIST_URL = f"{LINODE_DATABASES_BASE_URL}/instances"
 # in the listing but not here will be reported as a skip.
 SUPPORTED_DB_ENGINES = ("mysql", "postgresql")
 
+# Managed databases have no explicit firewall on/off toggle: the allow_list is
+# the firewall. An allow_list containing one of these "open to the world"
+# ranges effectively disables it. --db-enable-firewall strips these so only
+# explicitly-allowed IPs can connect.
+OPEN_ALLOW_LIST_RANGES = ("0.0.0.0/0", "::/0")
+
 
 def _auth_headers():
     """Build authorization headers for Linode API requests."""
@@ -125,9 +131,24 @@ def _format_database_label(database):
     return format_target(type_name, database.get("label", ""), database["id"])
 
 
-def _apply_ip_to_allow_list(allow_list, ip_with_mask, remove):
+def _has_open_range(allow_list):
+    """True if the allow_list contains an open-to-the-world range."""
+    return any(ip in OPEN_ALLOW_LIST_RANGES for ip in (allow_list or []))
+
+
+def _apply_ip_to_allow_list(allow_list, ip_with_mask, remove, enable_firewall=False):
     """
     Apply the IP change to an allow_list in a copy-safe manner.
+
+    Args:
+        allow_list (list): The current allow_list.
+        ip_with_mask (str): The address to add/remove (e.g. ``1.2.3.4/32``).
+        remove (bool): Remove the address instead of adding it.
+        enable_firewall (bool): When adding, also strip open-to-the-world ranges
+            (``0.0.0.0/0``, ``::/0``) so the database is only reachable from
+            explicitly-allowed IPs. Stripping an open range is itself a change,
+            so a database whose IP is already present but whose allow_list is
+            still open counts as ``changed``. Ignored in remove mode.
 
     Returns:
         tuple: (new_allow_list, changed, already_in_state)
@@ -142,10 +163,21 @@ def _apply_ip_to_allow_list(allow_list, ip_with_mask, remove):
         if ip_with_mask not in new_list:
             return new_list, False, True
         new_list = [ip for ip in new_list if ip != ip_with_mask]
-    else:
-        if ip_with_mask in new_list:
-            return new_list, False, True
+        return new_list, True, False
+
+    address_changed = ip_with_mask not in new_list
+    if address_changed:
         new_list.append(ip_with_mask)
+
+    lockdown_changed = False
+    if enable_firewall:
+        filtered = [ip for ip in new_list if ip not in OPEN_ALLOW_LIST_RANGES]
+        if len(filtered) != len(new_list):
+            new_list = filtered
+            lockdown_changed = True
+
+    if not address_changed and not lockdown_changed:
+        return new_list, False, True
 
     return new_list, True, False
 
@@ -201,7 +233,24 @@ def _check_skip_reason(database):
     return None
 
 
-def _process_database(database, ip_with_mask, remove, debug, quiet, dry_run, headers):
+def _report_database_change(db_label, ip_with_mask, remove, address_changed,
+                            locked_ranges, quiet, dry_run):
+    """Print the per-database result line(s) for an applied change."""
+    if quiet:
+        return
+    if address_changed:
+        line = (format_dry_run(ip_with_mask, db_label, remove=remove)
+                if dry_run
+                else format_result(ip_with_mask, db_label, remove=remove))
+        print(line)
+    if locked_ranges:
+        prefix = "[DRY RUN] Would remove" if dry_run else "Removed"
+        ranges = ", ".join(locked_ranges)
+        print(f"{prefix} open range(s) ({ranges}) from {db_label}")
+
+
+def _process_database(database, ip_with_mask, remove, debug, quiet, dry_run, headers,
+                      enable_firewall=False):
     """Apply the IP change to a single database's allow_list."""
     db_label = _format_database_label(database)
 
@@ -217,25 +266,36 @@ def _process_database(database, ip_with_mask, remove, debug, quiet, dry_run, hea
     if debug:
         print(f"Current allow_list for {db_label}: {allow_list}")
 
-    new_list, changed, _ = _apply_ip_to_allow_list(allow_list, ip_with_mask, remove)
+    new_list, changed, _ = _apply_ip_to_allow_list(
+        allow_list, ip_with_mask, remove, enable_firewall=enable_firewall,
+    )
     if not changed:
         _report_unchanged(db_label, ip_with_mask, remove, quiet)
         return "unchanged"
 
+    was_present = ip_with_mask in (allow_list or [])
+    address_changed = was_present if remove else not was_present
+    locked_ranges = (
+        [r for r in OPEN_ALLOW_LIST_RANGES if r in (allow_list or [])]
+        if enable_firewall and not remove
+        else []
+    )
+
     if dry_run:
-        if not quiet:
-            print(format_dry_run(ip_with_mask, db_label, remove=remove))
+        _report_database_change(db_label, ip_with_mask, remove,
+                                address_changed, locked_ranges, quiet, dry_run=True)
         return "changed"
 
     if not _commit_allow_list_change(database, db_label, new_list, headers, debug):
         return "failed"
 
-    if not quiet:
-        print(format_result(ip_with_mask, db_label, remove=remove))
+    _report_database_change(db_label, ip_with_mask, remove,
+                            address_changed, locked_ranges, quiet, dry_run=False)
     return "changed"
 
 
-def update_all_database_acls(debug=False, quiet=False, dry_run=False, remove=False, implicit=False):
+def update_all_database_acls(debug=False, quiet=False, dry_run=False, remove=False,
+                             implicit=False, enable_firewall=False):
     """
     Add (or remove) the current public IP on every managed database's allow_list.
 
@@ -248,6 +308,9 @@ def update_all_database_acls(debug=False, quiet=False, dry_run=False, remove=Fal
             +database run (i.e., user did not pass ``--database`` explicitly).
             Suppresses the "No managed databases found" notice so users without
             any databases see no extra output.
+        enable_firewall (bool): When adding, strip open-to-the-world ranges
+            (``0.0.0.0/0``, ``::/0``) from each database's allow_list so only
+            explicitly-allowed IPs can connect. No effect in remove mode.
 
     Returns:
         dict: Summary counts: ``changed``, ``unchanged``, ``skipped``,
@@ -269,7 +332,8 @@ def update_all_database_acls(debug=False, quiet=False, dry_run=False, remove=Fal
 
     counts = {"changed": 0, "unchanged": 0, "skipped": 0, "failed": 0, "total": len(databases)}
     for database in databases:
-        result = _process_database(database, ip_with_mask, remove, debug, quiet, dry_run, headers)
+        result = _process_database(database, ip_with_mask, remove, debug, quiet, dry_run,
+                                   headers, enable_firewall=enable_firewall)
         counts[result] = counts.get(result, 0) + 1
 
     if not quiet:

--- a/src/acc_fwu/lke.py
+++ b/src/acc_fwu/lke.py
@@ -141,9 +141,19 @@ def _format_cluster_label(cluster):
     return format_target(type_name, cluster.get("label", ""), cluster["id"])
 
 
-def _apply_ip_to_acl(acl, ip_with_mask, remove):
+def _apply_ip_to_acl(acl, ip_with_mask, remove, enable_acl=False):
     """
     Apply the IP change to an ACL dict in-place-safe manner.
+
+    Args:
+        acl (dict): The current normalized ACL.
+        ip_with_mask (str): The address to add/remove (e.g. ``1.2.3.4/32``).
+        remove (bool): Remove the address instead of adding it.
+        enable_acl (bool): When adding, also flip ``enabled`` to True if the
+            Control Plane ACL is currently disabled. Turning the ACL on is
+            itself a change, so a cluster whose IP is already present but whose
+            ACL is disabled still counts as ``changed``. Ignored in remove mode
+            (enabling a firewall while withdrawing your own IP is contradictory).
 
     Returns:
         tuple: (new_acl, changed, already_in_state)
@@ -154,18 +164,24 @@ def _apply_ip_to_acl(acl, ip_with_mask, remove):
     """
     ipv4 = list(acl.get("addresses", {}).get("ipv4", []))
     ipv6 = list(acl.get("addresses", {}).get("ipv6", []))
+    enabled = acl.get("enabled", False)
 
     if remove:
-        if ip_with_mask not in ipv4:
-            return acl, False, True
-        ipv4 = [ip for ip in ipv4 if ip != ip_with_mask]
+        address_changed = ip_with_mask in ipv4
+        if address_changed:
+            ipv4 = [ip for ip in ipv4 if ip != ip_with_mask]
     else:
-        if ip_with_mask in ipv4:
-            return acl, False, True
-        ipv4.append(ip_with_mask)
+        address_changed = ip_with_mask not in ipv4
+        if address_changed:
+            ipv4.append(ip_with_mask)
+
+    enable_changed = bool(enable_acl) and not remove and not enabled
+
+    if not address_changed and not enable_changed:
+        return acl, False, True
 
     new_acl = {
-        "enabled": acl.get("enabled", False),
+        "enabled": True if enable_changed else enabled,
         "addresses": {"ipv4": ipv4, "ipv6": ipv6},
     }
     return new_acl, True, False
@@ -207,10 +223,27 @@ def _report_unchanged(cluster_label, ip_with_mask, remove, quiet):
 def _maybe_warn_disabled(acl, cluster_label, remove, quiet):
     if not acl.get("enabled") and not remove and not quiet:
         print(f"Warning: Control Plane ACL is disabled on {cluster_label}; "
-              "address will be stored but not enforced until ACL is enabled.")
+              "address will be stored but not enforced until ACL is enabled "
+              "(pass --lke-enable-acl to enable it automatically).")
 
 
-def _process_cluster(cluster, ip_with_mask, remove, debug, quiet, dry_run, headers):
+def _report_cluster_change(cluster_label, ip_with_mask, remove, address_changed,
+                           enabling, quiet, dry_run):
+    """Print the per-cluster result line(s) for an applied change."""
+    if quiet:
+        return
+    if address_changed:
+        line = (format_dry_run(ip_with_mask, cluster_label, remove=remove)
+                if dry_run
+                else format_result(ip_with_mask, cluster_label, remove=remove))
+        print(line)
+    if enabling:
+        prefix = "[DRY RUN] Would enable" if dry_run else "Enabled"
+        print(f"{prefix} Control Plane ACL on {cluster_label}")
+
+
+def _process_cluster(cluster, ip_with_mask, remove, debug, quiet, dry_run, headers,
+                     enable_acl=False):
     """Apply the IP change to a single cluster's Control Plane ACL."""
     cluster_label = _format_cluster_label(cluster)
 
@@ -221,27 +254,35 @@ def _process_cluster(cluster, ip_with_mask, remove, debug, quiet, dry_run, heade
     if debug:
         print(f"Current ACL for {cluster_label}: {acl}")
 
-    new_acl, changed, _ = _apply_ip_to_acl(acl, ip_with_mask, remove)
+    new_acl, changed, _ = _apply_ip_to_acl(acl, ip_with_mask, remove, enable_acl=enable_acl)
     if not changed:
         _report_unchanged(cluster_label, ip_with_mask, remove, quiet)
         return "unchanged"
 
+    was_present = ip_with_mask in acl.get("addresses", {}).get("ipv4", [])
+    address_changed = was_present if remove else not was_present
+    enabling = enable_acl and not remove and not acl.get("enabled", False)
+
     if dry_run:
-        if not quiet:
-            print(format_dry_run(ip_with_mask, cluster_label, remove=remove))
+        _report_cluster_change(cluster_label, ip_with_mask, remove,
+                               address_changed, enabling, quiet, dry_run=True)
         return "changed"
 
-    _maybe_warn_disabled(acl, cluster_label, remove, quiet)
+    # If we are not enabling the ACL ourselves, warn when it is disabled so the
+    # user knows the stored address will not be enforced yet.
+    if not enabling:
+        _maybe_warn_disabled(acl, cluster_label, remove, quiet)
 
     if not _commit_acl_change(cluster, cluster_label, new_acl, headers, debug):
         return "failed"
 
-    if not quiet:
-        print(format_result(ip_with_mask, cluster_label, remove=remove))
+    _report_cluster_change(cluster_label, ip_with_mask, remove,
+                           address_changed, enabling, quiet, dry_run=False)
     return "changed"
 
 
-def update_all_lke_acls(debug=False, quiet=False, dry_run=False, remove=False, implicit=False):
+def update_all_lke_acls(debug=False, quiet=False, dry_run=False, remove=False,
+                        implicit=False, enable_acl=False):
     """
     Add (or remove) the current public IP on every LKE/LKE-E Control Plane ACL.
 
@@ -253,6 +294,9 @@ def update_all_lke_acls(debug=False, quiet=False, dry_run=False, remove=False, i
         implicit (bool): True when this call is part of the default firewall+LKE
             run (i.e., user did not pass ``--lke`` explicitly). Suppresses the
             "No LKE clusters found" notice so users without LKE see no noise.
+        enable_acl (bool): When adding, enable each cluster's Control Plane ACL
+            if it is currently disabled, so the added IP is actually enforced.
+            No effect in remove mode.
 
     Returns:
         dict: Summary counts: ``changed``, ``unchanged``, ``skipped``,
@@ -273,7 +317,8 @@ def update_all_lke_acls(debug=False, quiet=False, dry_run=False, remove=False, i
 
     counts = {"changed": 0, "unchanged": 0, "skipped": 0, "failed": 0, "total": len(clusters)}
     for cluster in clusters:
-        result = _process_cluster(cluster, ip_with_mask, remove, debug, quiet, dry_run, headers)
+        result = _process_cluster(cluster, ip_with_mask, remove, debug, quiet, dry_run,
+                                  headers, enable_acl=enable_acl)
         counts[result] = counts.get(result, 0) + 1
 
     if not quiet:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -510,7 +510,9 @@ class TestCliLkeFlag:
 
         main()
 
-        mock_update.assert_called_once_with(debug=False, quiet=False, dry_run=False, remove=False)
+        mock_update.assert_called_once_with(
+            debug=False, quiet=False, dry_run=False, remove=False, enable_acl=False,
+        )
 
     def test_main_with_lke_and_remove(self, monkeypatch):
         """Test --lke -r passes remove=True."""
@@ -520,7 +522,9 @@ class TestCliLkeFlag:
 
         main()
 
-        mock_update.assert_called_once_with(debug=False, quiet=False, dry_run=False, remove=True)
+        mock_update.assert_called_once_with(
+            debug=False, quiet=False, dry_run=False, remove=True, enable_acl=False,
+        )
 
     def test_main_with_lke_dry_run_and_quiet(self, monkeypatch):
         """Test --lke honors --dry-run and --quiet."""
@@ -530,7 +534,21 @@ class TestCliLkeFlag:
 
         main()
 
-        mock_update.assert_called_once_with(debug=False, quiet=True, dry_run=True, remove=False)
+        mock_update.assert_called_once_with(
+            debug=False, quiet=True, dry_run=True, remove=False, enable_acl=False,
+        )
+
+    def test_lke_enable_acl_flag_propagates(self, monkeypatch):
+        """--lke --lke-enable-acl passes enable_acl=True."""
+        mock_update = mock.MagicMock()
+        monkeypatch.setattr("acc_fwu.cli.update_all_lke_acls", mock_update)
+        monkeypatch.setattr(sys, "argv", ["acc-fwu", "--lke", "--lke-enable-acl"])
+
+        main()
+
+        mock_update.assert_called_once_with(
+            debug=False, quiet=False, dry_run=False, remove=False, enable_acl=True,
+        )
 
     def test_main_with_lke_list(self, monkeypatch, capsys):
         """Test --lke --list shows LKE clusters and exits without touching ACLs."""
@@ -637,6 +655,7 @@ class TestCliDefaultLkeBehavior:
         mock_update_fw.assert_called_once()
         mock_update_lke.assert_called_once_with(
             debug=False, quiet=False, dry_run=False, remove=False, implicit=True,
+            enable_acl=False,
         )
 
     def test_no_lke_flag_skips_lke_update(self, monkeypatch):
@@ -675,6 +694,34 @@ class TestCliDefaultLkeBehavior:
         mock_remove_fw.assert_called_once()
         mock_update_lke.assert_called_once_with(
             debug=False, quiet=False, dry_run=False, remove=True, implicit=True,
+            enable_acl=False,
+        )
+
+    def test_enable_flags_propagate_to_implicit_updates(self, monkeypatch):
+        """The enable switches reach the implicit LKE and database updates too."""
+        mock_load = mock.MagicMock(return_value=("12345", "Label"))
+        mock_update_fw = mock.MagicMock()
+        mock_update_lke = mock.MagicMock()
+        mock_update_db = mock.MagicMock()
+
+        monkeypatch.setattr("acc_fwu.cli.load_config", mock_load)
+        monkeypatch.setattr("acc_fwu.cli.update_firewall_rule", mock_update_fw)
+        monkeypatch.setattr("acc_fwu.cli.update_all_lke_acls", mock_update_lke)
+        monkeypatch.setattr("acc_fwu.cli.update_all_database_acls", mock_update_db)
+        monkeypatch.setattr(
+            sys, "argv",
+            ["acc-fwu", "--lke-enable-acl", "--db-enable-firewall"],
+        )
+
+        main()
+
+        mock_update_lke.assert_called_once_with(
+            debug=False, quiet=False, dry_run=False, remove=False, implicit=True,
+            enable_acl=True,
+        )
+        mock_update_db.assert_called_once_with(
+            debug=False, quiet=False, dry_run=False, remove=False, implicit=True,
+            enable_firewall=True,
         )
 
 
@@ -699,6 +746,7 @@ class TestCliDefaultDatabaseBehavior:
         mock_update_fw.assert_called_once()
         mock_update_db.assert_called_once_with(
             debug=False, quiet=False, dry_run=False, remove=False, implicit=True,
+            enable_firewall=False,
         )
 
     def test_no_database_flag_skips_database_update(self, monkeypatch):
@@ -737,6 +785,7 @@ class TestCliDefaultDatabaseBehavior:
         mock_remove_fw.assert_called_once()
         mock_update_db.assert_called_once_with(
             debug=False, quiet=False, dry_run=False, remove=True, implicit=True,
+            enable_firewall=False,
         )
 
 
@@ -755,7 +804,7 @@ class TestCliDatabaseFlag:
         main()
 
         mock_update.assert_called_once_with(
-            debug=False, quiet=False, dry_run=False, remove=False,
+            debug=False, quiet=False, dry_run=False, remove=False, enable_firewall=False,
         )
         mock_update_fw.assert_not_called()
 
@@ -768,7 +817,7 @@ class TestCliDatabaseFlag:
         main()
 
         mock_update.assert_called_once_with(
-            debug=False, quiet=False, dry_run=False, remove=True,
+            debug=False, quiet=False, dry_run=False, remove=True, enable_firewall=False,
         )
 
     def test_database_dry_run_quiet(self, monkeypatch):
@@ -780,7 +829,19 @@ class TestCliDatabaseFlag:
         main()
 
         mock_update.assert_called_once_with(
-            debug=False, quiet=True, dry_run=True, remove=False,
+            debug=False, quiet=True, dry_run=True, remove=False, enable_firewall=False,
+        )
+
+    def test_db_enable_firewall_flag_propagates(self, monkeypatch):
+        """--database --db-enable-firewall passes enable_firewall=True."""
+        mock_update = mock.MagicMock()
+        monkeypatch.setattr("acc_fwu.cli.update_all_database_acls", mock_update)
+        monkeypatch.setattr(sys, "argv", ["acc-fwu", "--database", "--db-enable-firewall"])
+
+        main()
+
+        mock_update.assert_called_once_with(
+            debug=False, quiet=False, dry_run=False, remove=False, enable_firewall=True,
         )
 
     def test_database_list_shows_databases_and_exits(self, monkeypatch, capsys):

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -166,6 +166,38 @@ class TestApplyIpToAllowList:
         assert original == ["1.1.1.1/32"]
         assert new_list != original
 
+    def test_enable_firewall_strips_open_ranges(self):
+        new_list, changed, already = _apply_ip_to_allow_list(
+            ["0.0.0.0/0", "::/0"], "2.2.2.2/32", remove=False, enable_firewall=True,
+        )
+        assert changed is True
+        assert already is False
+        assert new_list == ["2.2.2.2/32"]
+
+    def test_enable_firewall_is_change_even_if_ip_present(self):
+        """An open allow_list already containing the IP still changes: it locks down."""
+        new_list, changed, already = _apply_ip_to_allow_list(
+            ["2.2.2.2/32", "0.0.0.0/0"], "2.2.2.2/32", remove=False, enable_firewall=True,
+        )
+        assert changed is True
+        assert already is False
+        assert new_list == ["2.2.2.2/32"]
+
+    def test_enable_firewall_noop_when_already_locked_down(self):
+        _, changed, already = _apply_ip_to_allow_list(
+            ["2.2.2.2/32"], "2.2.2.2/32", remove=False, enable_firewall=True,
+        )
+        assert changed is False
+        assert already is True
+
+    def test_enable_firewall_ignored_in_remove_mode(self):
+        """--db-enable-firewall must not strip open ranges while removing an IP."""
+        new_list, changed, _ = _apply_ip_to_allow_list(
+            ["2.2.2.2/32", "0.0.0.0/0"], "2.2.2.2/32", remove=True, enable_firewall=True,
+        )
+        assert changed is True
+        assert new_list == ["0.0.0.0/0"]
+
 
 class TestUpdateAllDatabaseAcls:
     def _setup_common(self, monkeypatch, databases, ip="9.9.9.9"):
@@ -346,6 +378,59 @@ class TestUpdateAllDatabaseAcls:
         assert put_mock.call_args[0][1] == "mysql"
         captured = capsys.readouterr()
         assert "unsupported engine" in captured.err
+
+    def test_enable_firewall_strips_open_range(self, monkeypatch, capsys):
+        databases = [{"id": 1, "label": "primary", "engine": "mysql",
+                      "allow_list": ["0.0.0.0/0"]}]
+        put_mock = self._setup_common(monkeypatch, databases)
+
+        counts = update_all_database_acls(quiet=False, enable_firewall=True)
+
+        assert counts["changed"] == 1
+        sent = put_mock.call_args[0][2]
+        assert "0.0.0.0/0" not in sent
+        assert "9.9.9.9/32" in sent
+        captured = capsys.readouterr()
+        assert "Removed open range(s) (0.0.0.0/0)" in captured.out
+
+    def test_enable_firewall_locks_down_even_when_ip_present(self, monkeypatch, capsys):
+        databases = [{"id": 1, "label": "primary", "engine": "mysql",
+                      "allow_list": ["9.9.9.9/32", "0.0.0.0/0", "::/0"]}]
+        put_mock = self._setup_common(monkeypatch, databases)
+
+        counts = update_all_database_acls(quiet=False, enable_firewall=True)
+
+        assert counts["changed"] == 1
+        put_mock.assert_called_once()
+        sent = put_mock.call_args[0][2]
+        assert sent == ["9.9.9.9/32"]
+        captured = capsys.readouterr()
+        # IP already present, so only the lockdown line, no "Added".
+        assert "Removed open range(s) (0.0.0.0/0, ::/0)" in captured.out
+        assert "Added" not in captured.out
+
+    def test_enable_firewall_noop_without_open_ranges(self, monkeypatch):
+        databases = [{"id": 1, "label": "primary", "engine": "mysql",
+                      "allow_list": ["9.9.9.9/32"]}]
+        put_mock = self._setup_common(monkeypatch, databases)
+
+        counts = update_all_database_acls(quiet=True, enable_firewall=True)
+
+        assert counts["unchanged"] == 1
+        assert counts["changed"] == 0
+        put_mock.assert_not_called()
+
+    def test_enable_firewall_dry_run_does_not_put(self, monkeypatch, capsys):
+        databases = [{"id": 1, "label": "primary", "engine": "mysql",
+                      "allow_list": ["0.0.0.0/0"]}]
+        put_mock = self._setup_common(monkeypatch, databases)
+
+        counts = update_all_database_acls(dry_run=True, enable_firewall=True)
+
+        put_mock.assert_not_called()
+        assert counts["changed"] == 1
+        captured = capsys.readouterr()
+        assert "[DRY RUN] Would remove open range(s) (0.0.0.0/0)" in captured.out
 
     def test_put_failure_is_counted(self, monkeypatch, capsys):
         databases = [{"id": 1, "label": "primary", "engine": "mysql",

--- a/tests/test_lke.py
+++ b/tests/test_lke.py
@@ -162,6 +162,45 @@ class TestApplyIpToAcl:
         assert new_acl["enabled"] is False
         assert new_acl["addresses"]["ipv6"] == ["::/0"]
 
+    def test_enable_acl_flips_disabled_when_adding(self):
+        acl = {"enabled": False, "addresses": {"ipv4": [], "ipv6": []}}
+        new_acl, changed, already = _apply_ip_to_acl(
+            acl, "2.2.2.2/32", remove=False, enable_acl=True,
+        )
+        assert changed is True
+        assert already is False
+        assert new_acl["enabled"] is True
+        assert "2.2.2.2/32" in new_acl["addresses"]["ipv4"]
+
+    def test_enable_acl_is_change_even_if_ip_present(self):
+        """A disabled ACL that already contains the IP still changes: enabling it."""
+        acl = {"enabled": False, "addresses": {"ipv4": ["2.2.2.2/32"], "ipv6": []}}
+        new_acl, changed, already = _apply_ip_to_acl(
+            acl, "2.2.2.2/32", remove=False, enable_acl=True,
+        )
+        assert changed is True
+        assert already is False
+        assert new_acl["enabled"] is True
+        assert new_acl["addresses"]["ipv4"] == ["2.2.2.2/32"]
+
+    def test_enable_acl_noop_when_already_enabled_and_present(self):
+        acl = {"enabled": True, "addresses": {"ipv4": ["2.2.2.2/32"], "ipv6": []}}
+        _, changed, already = _apply_ip_to_acl(
+            acl, "2.2.2.2/32", remove=False, enable_acl=True,
+        )
+        assert changed is False
+        assert already is True
+
+    def test_enable_acl_ignored_in_remove_mode(self):
+        """--lke-enable-acl must not re-enable a disabled ACL while removing an IP."""
+        acl = {"enabled": False, "addresses": {"ipv4": ["2.2.2.2/32"], "ipv6": []}}
+        new_acl, changed, _ = _apply_ip_to_acl(
+            acl, "2.2.2.2/32", remove=True, enable_acl=True,
+        )
+        assert changed is True
+        assert new_acl["enabled"] is False
+        assert "2.2.2.2/32" not in new_acl["addresses"]["ipv4"]
+
 
 class TestUpdateAllLkeAcls:
     def _setup_common(self, monkeypatch, clusters, acls_by_id, ip="9.9.9.9"):
@@ -266,6 +305,50 @@ class TestUpdateAllLkeAcls:
         captured = capsys.readouterr()
         assert "Warning" in captured.out
         assert "disabled" in captured.out
+
+    def test_enable_acl_enables_disabled_cluster(self, monkeypatch, capsys):
+        clusters = [{"id": 1, "label": "std", "tier": "standard"}]
+        acls = {1: {"enabled": False, "addresses": {"ipv4": [], "ipv6": []}}}
+        put_mock = self._setup_common(monkeypatch, clusters, acls)
+
+        counts = update_all_lke_acls(quiet=False, enable_acl=True)
+
+        assert counts["changed"] == 1
+        sent = put_mock.call_args[0][1]
+        assert sent["enabled"] is True
+        assert "9.9.9.9/32" in sent["addresses"]["ipv4"]
+        captured = capsys.readouterr()
+        # No "disabled" warning when we are enabling it ourselves.
+        assert "Warning" not in captured.out
+        assert "Enabled Control Plane ACL" in captured.out
+
+    def test_enable_acl_flips_even_when_ip_present(self, monkeypatch, capsys):
+        clusters = [{"id": 1, "label": "std", "tier": "standard"}]
+        acls = {1: {"enabled": False, "addresses": {"ipv4": ["9.9.9.9/32"], "ipv6": []}}}
+        put_mock = self._setup_common(monkeypatch, clusters, acls)
+
+        counts = update_all_lke_acls(quiet=False, enable_acl=True)
+
+        assert counts["changed"] == 1
+        put_mock.assert_called_once()
+        sent = put_mock.call_args[0][1]
+        assert sent["enabled"] is True
+        captured = capsys.readouterr()
+        # IP was already present, so no "Added" line, only the enable line.
+        assert "Enabled Control Plane ACL" in captured.out
+        assert "Added" not in captured.out
+
+    def test_enable_acl_dry_run_does_not_put(self, monkeypatch, capsys):
+        clusters = [{"id": 1, "label": "std", "tier": "standard"}]
+        acls = {1: {"enabled": False, "addresses": {"ipv4": [], "ipv6": []}}}
+        put_mock = self._setup_common(monkeypatch, clusters, acls)
+
+        counts = update_all_lke_acls(dry_run=True, enable_acl=True)
+
+        put_mock.assert_not_called()
+        assert counts["changed"] == 1
+        captured = capsys.readouterr()
+        assert "[DRY RUN] Would enable Control Plane ACL" in captured.out
 
     def test_get_acl_failure_is_counted(self, monkeypatch, capsys):
         clusters = [


### PR DESCRIPTION
## Summary

Adds two opt-in switches that let `acc-fwu` turn the firewall **on** for LKE clusters and managed databases, rather than only adding the current IP to a firewall that may still be disabled or wide open.

- **`--lke-enable-acl`** — When adding, enable a cluster's Control Plane ACL if it is currently disabled, so the stored address is actually enforced. Previously the tool preserved the `enabled` state and only printed a warning. The enable is itself a change (a disabled ACL that already contains the IP still counts as `changed`), and it suppresses the "ACL is disabled" warning for that cluster. Ignored in remove mode.
- **`--db-enable-firewall`** — Managed databases have no firewall on/off toggle in the Linode API (the `allow_list` *is* the firewall, and `0.0.0.0/0` / `::/0` leave it open to the world). This switch strips those open ranges from the `allow_list` while adding your IP, so only explicitly-allowed addresses can connect. The IP is always appended before open ranges are removed, so the list is never left empty (which would block all connections). Ignored in remove mode.

Both switches work in the default combined run (e.g. `acc-fwu --lke-enable-acl --db-enable-firewall`) and in the explicit `--lke` / `--database` modes.

## Changes

- `src/acc_fwu/lke.py` — `_apply_ip_to_acl` and `update_all_lke_acls` take `enable_acl`; new per-cluster reporting emits an "Enabled Control Plane ACL" line (and dry-run variant).
- `src/acc_fwu/databases.py` — new `OPEN_ALLOW_LIST_RANGES` constant and `_has_open_range` helper; `_apply_ip_to_allow_list` and `update_all_database_acls` take `enable_firewall`; new per-database reporting emits a "Removed open range(s)" line (and dry-run variant).
- `src/acc_fwu/cli.py` — adds the `--lke-enable-acl` and `--db-enable-firewall` arguments and threads them through the explicit and implicit dispatch paths.
- Docs: `README.md` (features, options, LKE/database sections) and `CLAUDE.md`.

## Testing

- `pytest` — 198 passed (added unit tests for both apply-functions' add/idempotency/remove-mode behavior, orchestrator tests for enable/lockdown incl. dry-run, and CLI flag-propagation tests through both the explicit and default runs).
- `flake8` (E9/F63/F7/F82 and complexity/line-length) — clean.
- End-to-end dry-run smoke test with mocked API confirms the expected output lines and exit codes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0141VbdWsH5vew91aBzMhUto)_